### PR TITLE
Pdct 916/add precommit hook setup and usage to readme & converted relative imports to absolute

### DIFF
--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,11 +1,25 @@
 # Autoformatter friendly markdownlint config (all formatting rules disabled)
 default: true
-blank_lines: false
-bullet: false
-html: false
-indentation: false
-line_length: false
-spaces: false
-url: false
-whitespace: false
-tables: false
+
+MD013:
+  # Number of characters
+  line_length: 80
+
+  # Number of characters for headings
+  heading_line_length: 80
+
+  # Number of characters for code blocks
+  code_block_line_length: 80
+
+  # Include code blocks
+  headings: true
+
+  # Don't include tables
+  tables: false
+  code_blocks: false
+
+  # Strict length checking
+  strict: false
+
+  # Stern length checking
+  stern: false

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,0 +1,8 @@
+# Generic, formatter-friendly config.
+select = ["B", "D3", "E", "F"]
+
+# Never enforce `E501` (line length violations). This should be handled by formatters.
+ignore = ["E501"]
+
+[lint]
+ignore-init-module-imports = true

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ ifneq ($(trunk_installed),0)
 	$(eval OS_NAME=$(shell uname -s | tr A-Z a-z))
 ifeq ($(OS_NAME),linux)
 	curl https://get.trunk.io -fsSL | bash
+	trunk init
 endif
 ifeq ($(OS_NAME),darwin)
 	brew install trunk-io
+	trunk init
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifneq (${trunk_installed},0)
 	curl https://get.trunk.io -fsSL | bash
 endif
 
-git_hooks: install_trunk
+git_hooks:
 	trunk fmt
 	trunk check
 

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,9 @@
 
 install_trunk:
 	$(eval trunk_installed=$(shell trunk --version > /dev/null 2>&1 ; echo $$? ))
-ifneq ($(trunk_installed),0)
+ifneq (${trunk_installed},0)
 	$(eval OS_NAME=$(shell uname -s | tr A-Z a-z))
-ifeq ($(OS_NAME),linux)
 	curl https://get.trunk.io -fsSL | bash
-	trunk init
-endif
-ifeq ($(OS_NAME),darwin)
-	brew install trunk-io
-	trunk init
-endif
 endif
 
 git_hooks: install_trunk
@@ -21,3 +14,7 @@ git_hooks: install_trunk
 test:
 	docker compose build
 	docker compose run --rm db_client
+
+uninstall_trunk:
+	sudo rm -if `which trunk`
+	rm -ifr ${HOME}/.cache/trunk

--- a/README.md
+++ b/README.md
@@ -1,17 +1,27 @@
 # NAVIGATOR DB CLIENT
 
-All things to do with the datamodel and its storage. Including alembic migrations and datamodel code.
+All things to do with the data model and its storage. Including alembic
+migrations and data model code.
 
 ## Used by
 
 - [navigator-backend](https://github.com/climatepolicyradar/navigator-backend)
 - [navigator-admin-backend](https://github.com/climatepolicyradar/navigator-admin-backend)
 
-## Installation
+## Setting up the repository
+
+To install and run the pre-commit hooks (which run using Trunk.io), please run
+`make git_hooks`. This will install and initialise Trunk if it does not already
+exist in your PATH, and will always run Trunk's built-in linting `trunk check`
+and formatting `trunk fmt` tools.
+
+Read more about Trunk via their docs page [here](https://docs.trunk.io/).
+
+## How to use as dependency
 
 1. Include the following in the `pyproject.toml`:
 
-```
+```toml
 db-client = {git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = {LATEST_TAG}}
 ```
 
@@ -19,7 +29,8 @@ db-client = {git = "https://github.com/climatepolicyradar/navigator-db-client.gi
 
 ## Run migrations
 
-Migrations run automatically at the begginig of the backend service executions using the `db_client.run_migrations` function.
+Migrations run automatically at the beginning of the backend service executions
+using the `db_client.run_migrations` function.
 
 ## Make migrations
 
@@ -40,7 +51,7 @@ source .env
 pytest -vvv --cov=db_client --test-alembic --cov-fail-under=95
 ```
 
-## TODO:
+## TODO
 
 - [ ] Create more unit testing here
 - [ ] Automatic documentation for pipeline

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ migrations and data model code.
 ## Setting up the repository
 
 To install and run the pre-commit hooks (which run using Trunk.io), please run
-`make git_hooks`. This will install and initialise Trunk if it does not already
-exist in your PATH, and will always run Trunk's built-in linting `trunk check`
-and formatting `trunk fmt` tools.
+`make install_trunk`. This will install and initialise Trunk if it does not
+already exist in your PATH. Then, run `make git_hooks` to run Trunk's built-in
+linting `trunk check` and formatting `trunk fmt` tools.
 
 Read more about Trunk via their docs page [here](https://docs.trunk.io/).
 

--- a/db_client/__init__.py
+++ b/db_client/__init__.py
@@ -1,2 +1,5 @@
-from . import run_migrations as run_migrations_script
-from .run_migrations import run_migrations
+""" Export select function and module symbols. """
+
+from db_client.run_migrations import run_migrations
+
+__all__ = ("run_migrations",)

--- a/db_client/__init__.py
+++ b/db_client/__init__.py
@@ -1,5 +1,6 @@
 """ Export select function and module symbols. """
 
+import db_client.run_migrations as run_migrations_script
 from db_client.run_migrations import run_migrations
 
-__all__ = ("run_migrations",)
+__all__ = ("run_migrations", "run_migrations_script")

--- a/db_client/models/app/counters.py
+++ b/db_client/models/app/counters.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm.session import object_session
 from sqlalchemy.sql import text
 
-from ..base import Base
+from db_client.models.base import Base
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/db_client/models/app/users.py
+++ b/db_client/models/app/users.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy import PrimaryKeyConstraint
 
-from ..base import Base
+from db_client.models.base import Base
 
 
 class AppUser(Base):

--- a/db_client/models/document/__init__.py
+++ b/db_client/models/document/__init__.py
@@ -1,1 +1,5 @@
-from .physical_document import PhysicalDocument
+""" Export function and module symbols. """
+
+from db_client.models.document.physical_document import PhysicalDocument
+
+__all__ = ("PhysicalDocument",)

--- a/db_client/models/document/physical_document.py
+++ b/db_client/models/document/physical_document.py
@@ -4,8 +4,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
-from ...models.app.enum import BaseModelEnum
-from ..base import Base
+from db_client.models.app.enum import BaseModelEnum
+from db_client.models.base import Base
 
 
 # TODO Our current process for updating languages in the database relies on

--- a/db_client/models/law_policy/geography.py
+++ b/db_client/models/law_policy/geography.py
@@ -1,6 +1,6 @@
 import sqlalchemy as sa
 
-from ..base import Base
+from db_client.models.base import Base
 
 GEO_NONE = "XAA"
 GEO_INTERNATIONAL = "XAB"


### PR DESCRIPTION
# What's changed

- Convert remaining relative imports to absolute
- added how to install and use trunk to readme
- Fixed markdown line length violations
- Updated markdownlint config

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
