### PR TITLE
Fix auto tag job permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,6 +46,8 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    permissions: write-all
+
     needs:
       - code-quality
       - test

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,6 +72,8 @@ jobs:
 
   release:
     needs: tag
+    permissions:
+      contents: write
     uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@main
     with:
       new_tag: ${{ needs.tag.outputs.new_tag }}


### PR DESCRIPTION
# What's changed

Fix auto tag and release job permissions

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
