### PR TITLE
Change tag job permissions to content write only

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,8 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
-    permissions: write-all
+    permissions:
+      contents: write
 
     needs:
       - code-quality


### PR DESCRIPTION
# What's changed

Change tag job permissions to content write only

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
