### PR TITLE
Readd uninstall_trunk makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: test git_hooks
+.PHONEY: test git_hooks install_trunk uninstall_trunk
 
 install_trunk:
 	$(eval trunk_installed=$(shell trunk --version > /dev/null 2>&1 ; echo $$? ))
@@ -6,6 +6,10 @@ ifneq (${trunk_installed},0)
 	$(eval OS_NAME=$(shell uname -s | tr A-Z a-z))
 	curl https://get.trunk.io -fsSL | bash
 endif
+
+uninstall_trunk:
+	sudo rm -if `which trunk`
+	rm -ifr ${HOME}/.cache/trunk
 
 git_hooks:
 	trunk fmt


### PR DESCRIPTION
# What's changed

During the pytest-alembic merge PR, it seems an error sorting conflicts has wiped the uninstall_trunk makefile command. Readd this back in.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
