### PR TITLE
Pdct 994/configure pyright venvpath per dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,9 +83,8 @@ profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
+pyrightconfig.json
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/.trunk/configure-pyright-with-pyenv.sh
+++ b/.trunk/configure-pyright-with-pyenv.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Get the name of the expected venv for this repo from the pyproject.toml file.
-venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
+venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3) || true
 
 # Check if pyrightconfig already exists.
 if [[ ! -f pyrightconfig.json ]]; then

--- a/.trunk/configure-pyright-with-pyenv.sh
+++ b/.trunk/configure-pyright-with-pyenv.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+set -e
+
+# Get the name of the expected venv for this repo from the pyproject.toml file.
+venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
+
+# Check if pyrightconfig already exists.
+if [[ ! -f pyrightconfig.json ]]; then
+	# Check if pyenv-pyright plugin is installed
+	if ! command -v pyenv &>/dev/null; then
+		echo "pyenv not installed. Please install pyenv..."
+		exit 1
+	fi
+
+	# Check if pyenv-pyright plugin is installed
+	if ! command -v pyenv pyright &>/dev/null; then
+		echo "pyenv-pyright not installed. Installing..."
+		git clone https://github.com/alefpereira/pyenv-pyright.git "$(pyenv root)"/plugins/pyenv-pyright
+	fi
+
+	# Generate the pyrightconfig.json file.
+	pyenv pyright "${venv_name}"
+
+fi
+
+# Check whether required keys are present in pyrightconfig.json.
+if ! jq -r --arg venv_name "${venv_name}" '. | select(.venv != $venv_name) | select(.venvPath != null)' pyrightconfig.json; then
+	echo "Failed to configure pyright to use pyenv environment '${venv_name}' as interpreter. Please check pyrightconfig.json..."
+	exit 1
+fi
+exit 0

--- a/.trunk/configure-pyright-with-pyenv.sh
+++ b/.trunk/configure-pyright-with-pyenv.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Get the name of the expected venv for this repo from the pyproject.toml file.
-venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3) || true
+venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
 
 # Check if pyrightconfig already exists.
 if [[ ! -f pyrightconfig.json ]]; then

--- a/.trunk/configure-pyright-with-pyenv.sh
+++ b/.trunk/configure-pyright-with-pyenv.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-set -eux
+set -e
 
 # Get the name of the expected venv for this repo from the pyproject.toml file.
 venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)

--- a/.trunk/configure-pyright-with-pyenv.sh
+++ b/.trunk/configure-pyright-with-pyenv.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Get the name of the expected venv for this repo from the pyproject.toml file.
-venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
+venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3) || true
 
 # Check if pyrightconfig already exists.
 if [[ ! -f pyrightconfig.json ]]; then
@@ -15,7 +15,8 @@ if [[ ! -f pyrightconfig.json ]]; then
 	# Check if pyenv-pyright plugin is installed
 	if ! command -v pyenv pyright &>/dev/null; then
 		echo "pyenv-pyright not installed. Installing..."
-		git clone https://github.com/alefpereira/pyenv-pyright.git "$(pyenv root)"/plugins/pyenv-pyright
+		pyenv_root=$(pyenv root)
+		git clone https://github.com/alefpereira/pyenv-pyright.git "${pyenv_root}"/plugins/pyenv-pyright
 	fi
 
 	# Generate the pyrightconfig.json file.

--- a/.trunk/configure-pyright-with-pyenv.sh
+++ b/.trunk/configure-pyright-with-pyenv.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-set -e
+set -eux
 
 # Get the name of the expected venv for this repo from the pyproject.toml file.
 venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
@@ -20,6 +20,7 @@ if [[ ! -f pyrightconfig.json ]]; then
 
 	# Generate the pyrightconfig.json file.
 	pyenv pyright "${venv_name}"
+	pyenv local "${venv_name}"
 
 fi
 

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -67,9 +67,15 @@ lint:
 
 actions:
   disabled:
-    - trunk-announce
-    - trunk-check-pre-push
-  enabled:
     - trunk-check-pre-commit
+    - trunk-announce
+  enabled:
+    - trunk-check-pre-push
+    - configure-pyright-with-pyenv
     - trunk-fmt-pre-commit
     - trunk-upgrade-available
+  definitions:
+    - id: configure-pyright-with-pyenv
+      run: source .trunk/configure-pyright-with-pyenv.sh
+      triggers:
+        - git_hooks: [pre-commit]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -67,10 +67,10 @@ lint:
 
 actions:
   disabled:
-    - trunk-check-pre-commit
+    - trunk-check-pre-push
     - trunk-announce
   enabled:
-    - trunk-check-pre-push
+    - trunk-check-pre-commit
     - configure-pyright-with-pyenv
     - trunk-fmt-pre-commit
     - trunk-upgrade-available

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ uninstall_trunk:
 	sudo rm -if `which trunk`
 	rm -ifr ${HOME}/.cache/trunk
 
-git_hooks:
+check:
+	trunk actions run configure-pyright-with-pyenv
 	trunk fmt
 	trunk check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,4 @@ build-backend = "poetry.core.masonry.api"
 include = ["db_client", "tests"]
 exclude = ["**/__pycache__"]
 executionEnvironments = [{ "root" = "db_client" }]
+venv = "dbclient"


### PR DESCRIPTION
# What's changed

- Add a custom Trunk action to auto configure missing venv config information for Pyright if the file doesn't already exist
- Change run trunk check to pre-push rather than pre-commit

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
