### PR TITLE
Fix naming conflict of corpus_type

### DIFF
--- a/db_client/alembic/versions/0030_add_corpus_and_corpus_type.py
+++ b/db_client/alembic/versions/0030_add_corpus_and_corpus_type.py
@@ -2,7 +2,7 @@
 
 Revision ID: 0030
 Revises: 0029
-Create Date: 2024-03-20 16:46:11.829855
+Create Date: 2024-03-21 12:58:22.725699
 
 """
 
@@ -34,11 +34,11 @@ def upgrade():
         sa.Column("title", sa.Text(), nullable=False),
         sa.Column("description", sa.Text(), nullable=False),
         sa.Column("organisation_id", sa.Integer(), nullable=False),
-        sa.Column("corpus_type", sa.Text(), nullable=False),
+        sa.Column("corpus_type_name", sa.Text(), nullable=False),
         sa.ForeignKeyConstraint(
-            ["corpus_type"],
+            ["corpus_type_name"],
             ["corpus_type.name"],
-            name=op.f("fk_corpus__corpus_type__corpus_type"),
+            name=op.f("fk_corpus__corpus_type_name__corpus_type"),
         ),
         sa.ForeignKeyConstraint(
             ["organisation_id"],

--- a/db_client/models/organisation/corpus.py
+++ b/db_client/models/organisation/corpus.py
@@ -22,4 +22,4 @@ class Corpus(Base):
     title = sa.Column(sa.Text, nullable=False)
     description = sa.Column(sa.Text, nullable=False)
     organisation_id = sa.Column(sa.ForeignKey(Organisation.id), nullable=False)
-    corpus_type = sa.Column(sa.ForeignKey(CorpusType.name), nullable=False)
+    corpus_type_name = sa.Column(sa.ForeignKey(CorpusType.name), nullable=False)


### PR DESCRIPTION
# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
