### PR TITLE
PDCT 887 Add CCLW metadata and Corpus

### DIFF
--- a/db_client/alembic/versions/0031_cclw_corpus.py
+++ b/db_client/alembic/versions/0031_cclw_corpus.py
@@ -7,9 +7,10 @@ Create Date: 2024-03-21 sometime after breakfast
 """
 
 from alembic import op
-from data_migrations.taxonomy_cclw import get_cclw_taxonomy
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
+
+from db_client.data_migrations.taxonomy_cclw import get_cclw_taxonomy
 
 # revision identifiers, used by Alembic.
 revision = "0031"

--- a/db_client/alembic/versions/0031_cclw_corpus.py
+++ b/db_client/alembic/versions/0031_cclw_corpus.py
@@ -1,0 +1,93 @@
+"""Add the CCLW Corpus and Corpus Type (old taxonomy)
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2024-03-21 sometime after breakfast
+
+"""
+
+
+from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session 
+
+from data_migrations.taxonomy_cclw import get_cclw_taxonomy
+
+# revision identifiers, used by Alembic.
+revision = "0031"
+down_revision = "0030"
+branch_labels = None
+depends_on = None
+
+Base = automap_base()
+
+
+def get_cclw(session, Org):
+    return session.query(Org).filter(Org.name == "CCLW").one()
+
+
+def add_corpus_type(session, CorpusType, name, description, valid_metadata):
+    corpus_type = CorpusType(
+        name=name,
+        description=description,
+        valid_metadata=valid_metadata,
+    )
+    session.add(corpus_type)
+    session.flush()
+    return corpus_type
+
+
+def add_corpus(session, Corpus, EntityCounter, title, description, org, corpus_type):
+    counter = session.query(EntityCounter).filter(EntityCounter.prefix == org.name).one()
+    corpus = Corpus(
+        import_id = counter.create_import_id("corpus"),
+        title = title,
+        description = description,
+        organisation_id = org.id,
+        corpus_type = corpus_type,
+    )
+    session.add(corpus)
+    session.flush()
+    return corpus
+
+
+def link_families_to_corpus(session, FamilyOrganisation, FamilyCorpus, cclw, corpus):
+    families = session.query(FamilyOrganisation).filter(FamilyOrganisation.organisaton_id == cclw.id).all()
+    session.begin()
+    for family_import_id in [ f.import_id for f in families]:
+        # insert into FamilyCorpus
+        session.add(FamilyCorpus(
+            family_import_id = family_import_id,
+            corpus_import_id = corpus.import_id,
+        ))
+    session.commit()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session: Session = Session(bind=bind)
+
+    Base.prepare(autoload_with=bind)
+    Org = Base.classes.organisation
+    Corpus = Base.classes.corpus
+    CorpusType = Base.classes.corpus_type
+    EntityCounter = Base.classes.entity_counter
+    FamilyOrganisation = Base.classes.family_organisation
+    FamilyCorpus = Base.classes.family_corpus
+
+    # Create Corpus Types
+    law_and_policy = add_corpus_type(session, CorpusType, "Law & Policy", "Laws and policies", get_cclw_taxonomy())
+
+    # Create Corpus
+    cclw = get_cclw(session, Org)
+    corpus = add_corpus(session, Corpus, EntityCounter, "", "", cclw, law_and_policy)
+    session.commit()
+
+    # Link all families to their respective corpus
+    link_families_to_corpus(session, FamilyOrganisation, FamilyCorpus, cclw, corpus)
+
+
+def downgrade():
+    # There is no way back
+    pass
+


### PR DESCRIPTION
# What's changed

Added the migration to create a corpus and attach families to the corpus

# Tests

Tested locally on the production db dump from 6th March:

```
$ psql -d postgres -c "drop database navigator;"
$ psql -d postgres -c "create database navigator;"
$ psql -f ~/Documents/dumps/prod_2024_03_06.sql
$ psql

navigator=# select * from corpus;
              import_id               |         title          |      description       | organisation_id | corpus_type_name  
--------------------------------------+------------------------+------------------------+-----------------+-------------------
 LSE CCLW team.corpus.i00000001.n0000 | CCLW national policies | CCLW national policies |               1 | Laws and Policies
(1 row)

navigator=# select * from organisation where id=1;
 id |     name      |           description            | organisation_type 
----+---------------+----------------------------------+-------------------
  1 | LSE CCLW team | Climate Change Laws of the World | Academic
(1 row)


navigator=# select count(*) from family_corpus ;
 count 
-------
  3554
(1 row)

navigator=# select count(*) from family_organisation where organisation_id=1 ;
 count 
-------
  3554
(1 row)


```
## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
