### PR TITLE
PDCT-888 Add UNFCCC metadata and Corpus

### DIFF
--- a/db_client/alembic/versions/0032_unfccc_corpus.py
+++ b/db_client/alembic/versions/0032_unfccc_corpus.py
@@ -1,0 +1,102 @@
+"""Add the UNFCCC Corpus and Corpus Type (old taxonomy)
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2024-03-21 sometime after breakfast
+
+"""
+
+from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
+
+from db_client.data_migrations.taxonomy_cclw import get_cclw_taxonomy
+
+# revision identifiers, used by Alembic.
+revision = "0032"
+down_revision = "0031"
+branch_labels = None
+depends_on = None
+
+Base = automap_base()
+
+
+def get_unfccc(session, Org):
+    return session.query(Org).filter(Org.name == "UNFCCC").one()
+
+
+def add_corpus_type(session, CorpusType, name, description, valid_metadata):
+    corpus_type = CorpusType(
+        name=name,
+        description=description,
+        valid_metadata=valid_metadata,
+    )
+    session.add(corpus_type)
+    session.flush()
+    return corpus_type
+
+
+def add_corpus(session, Corpus, title, description, org, corpus_type):
+    # NOTE: we cannot use create_import_id here.. so pinch the code
+    n = 0  # The fourth quad is historical
+    i_value = str(1).zfill(8)
+    n_value = str(n).zfill(4)
+    import_id = f"{org.name}.corpus.i{i_value}.n{n_value}"
+    corpus = Corpus(
+        import_id=import_id,
+        title=title,
+        description=description,
+        organisation_id=org.id,
+        corpus_type=corpus_type,
+    )
+    session.add(corpus)
+    session.flush()
+    return corpus
+
+
+def link_families_to_corpus(session, families, corpus):
+    session.begin(subtransactions=True)
+
+    for family in families:
+        # insert into FamilyCorpus
+        family.corpus_collection.append(corpus)
+    session.commit()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session: Session = Session(bind=bind)
+
+    Base.prepare(autoload_with=bind)
+    Org = Base.classes.organisation
+    Corpus = Base.classes.corpus
+    CorpusType = Base.classes.corpus_type
+
+    # Create Corpus Types
+    intl_agreements = add_corpus_type(
+        session,
+        CorpusType,
+        "Intl. agreements",
+        "Intl. agreements",
+        get_cclw_taxonomy(),
+    )
+
+    # Create Corpus
+    unfccc = get_unfccc(session, Org)
+    corpus = add_corpus(
+        session,
+        Corpus,
+        "UNFCCC Submissions",
+        "UNFCCC Submissions",
+        unfccc,
+        intl_agreements,
+    )
+    session.commit()
+
+    # Link all families to their respective corpus
+    link_families_to_corpus(session, unfccc.family_collection, corpus)
+
+
+def downgrade():
+    # There is no way back
+    pass


### PR DESCRIPTION
# What's changed

Added the migration to create a corpus and attach families to the corpus

# Tests

Tested locally on the production db dump from 6th March:

```
$ psql -d postgres -c "drop database navigator;"
$ psql -d postgres -c "create database navigator;"
$ psql -f ~/Documents/dumps/prod_2024_03_06.sql
$ alembic upgrade head
$ psql

navigator=# select * from corpus;
              import_id               |         title          |      description       | organisation_id | corpus_type_name  
--------------------------------------+------------------------+------------------------+-----------------+-------------------
 LSE CCLW team.corpus.i00000001.n0000 | CCLW national policies | CCLW national policies |               1 | Laws and Policies
 UNFCCC.corpus.i00000001.n0000        | UNFCCC Submissions     | UNFCCC Submissions     |               3 | Intl. agreements
(2 rows)

navigator=# select corpus_import_id, count(*) from family_corpus group by corpus_import_id;
           corpus_import_id           | count 
--------------------------------------+-------
 LSE CCLW team.corpus.i00000001.n0000 |  3554
 UNFCCC.corpus.i00000001.n0000        |  1654
(2 rows)

navigator=# select count(*) from family_corpus ;
 count 
-------
  3554
(1 row)
                                                             ^
navigator=# select organisation_id, count(*) from family_organisation group by organisation_id ;
 organisation_id | count 
-----------------+-------
               1 |  3554
               3 |  1654
(2 rows)

```

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
