### PR TITLE
Revert the renaming of the org - as we use this for import_id's

### DIFF
--- a/db_client/alembic/versions/0031_cclw_corpus.py
+++ b/db_client/alembic/versions/0031_cclw_corpus.py
@@ -84,7 +84,7 @@ def upgrade():
     # Create Corpus
     cclw = get_cclw(session, Org)
     # Change the name
-    cclw.name = "LSE CCLW team"
+    cclw.description = "LSE CCLW team"
     corpus = add_corpus(
         session,
         Corpus,


### PR DESCRIPTION
# What's changed

See title

Test:
```

navigator=# select * from organisation;
 id |  name  |                      description                      | organisation_type 
----+--------+-------------------------------------------------------+-------------------
  3 | UNFCCC | United Nations Framework Convention on Climate Change | UN
  1 | CCLW   | LSE CCLW team                                         | Academic
(2 rows)

navigator=# select * from corpus;
           import_id           |         title          |      description       | organisation_id | corpus_type_name  
-------------------------------+------------------------+------------------------+-----------------+-------------------
 CCLW.corpus.i00000001.n0000   | CCLW national policies | CCLW national policies |               1 | Laws and Policies
 UNFCCC.corpus.i00000001.n0000 | UNFCCC Submissions     | UNFCCC Submissions     |               3 | Intl. agreements
(2 rows)

```
## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
