### PR TITLE
Use correct taxonomy for UNFCCC

### DIFF
--- a/db_client/alembic/versions/0033_fix_unfccc_taxonomy.py
+++ b/db_client/alembic/versions/0033_fix_unfccc_taxonomy.py
@@ -1,0 +1,49 @@
+"""Fix the UNFCCC taxonomy
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2024-03-02 sometime after breakfast
+
+"""
+
+from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
+
+from db_client.data_migrations.taxonomy_unf3c import get_unf3c_taxonomy
+
+# revision identifiers, used by Alembic.
+revision = "0033"
+down_revision = "0032"
+branch_labels = None
+depends_on = None
+
+Base = automap_base()
+
+INTL_AGREEMENTS = "Intl. agreements"
+
+
+def update_corpus_type_taxonomy(session, CorpusType, name, new_taxonomy):
+    # Get the exiting corpus type for Intl. agreements
+    unfccc_ct = session.query(CorpusType).filter(CorpusType.name == name).one()
+    # update
+    unfccc_ct.valid_metadata = new_taxonomy
+    # add
+    session.add(unfccc_ct)
+    session.commit()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session: Session = Session(bind=bind)
+
+    Base.prepare(autoload_with=bind)
+    CorpusType = Base.classes.corpus_type
+    update_corpus_type_taxonomy(
+        session, CorpusType, INTL_AGREEMENTS, get_unf3c_taxonomy()
+    )
+
+
+def downgrade():
+    # There is no way back
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "2.0.3"
+version = "2.1.0"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

Now uses the UNFCCC taxonomy for international agreements

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
