### PR TITLE
Use always() and ! cancelled() to avoid uncancellable workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,7 +23,7 @@ jobs:
 
   code-quality:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success')
     needs:
       - check-auto-tagging-will-work
@@ -36,7 +36,7 @@ jobs:
 
   test:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success')
     needs:
       - check-auto-tagging-will-work
@@ -71,7 +71,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.code-quality.result == 'success' && needs.test.result == 'success') &&
       startsWith(github.ref, 'refs/heads/main')
     permissions:
@@ -108,7 +108,7 @@ jobs:
 
   release:
     needs: tag
-    if: ${{ always() && (needs.tag.result == 'success' && needs.tag.outputs.new_tag != 'Skip')}}
+    if: ${{ ! cancelled() && always() && (needs.tag.result == 'success' && needs.tag.outputs.new_tag != 'Skip')}}
     permissions:
       contents: write
     uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@v3


### PR DESCRIPTION
# What's changed

Use always() and ! cancelled() to avoid uncancellable workflows

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
