### PR TITLE
Feature/pdct 1094 move event types into the taxonomy

### DIFF
--- a/db_client/alembic/versions/0036_add_event_type_to_unf3c_tax.py
+++ b/db_client/alembic/versions/0036_add_event_type_to_unf3c_tax.py
@@ -1,0 +1,49 @@
+"""Add event_type to UNFCCC taxonomy.
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2024-06-26 08:48:00.140151
+
+"""
+
+from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
+
+from db_client.data_migrations.taxonomy_unf3c import get_unf3c_taxonomy
+
+# revision identifiers, used by Alembic.
+revision = "0036"
+down_revision = "0035"
+branch_labels = None
+depends_on = None
+
+Base = automap_base()
+
+INTL_AGREEMENTS = "Intl. agreements"
+
+
+def update_corpus_type_taxonomy(session, CorpusType, name, new_taxonomy):
+    # Get the exiting corpus type for Intl. agreements
+    unfccc_ct = session.query(CorpusType).filter(CorpusType.name == name).one()
+    # update
+    unfccc_ct.valid_metadata = new_taxonomy
+    # add
+    session.add(unfccc_ct)
+    session.commit()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session: Session = Session(bind=bind)
+
+    Base.prepare(autoload_with=bind)
+    CorpusType = Base.classes.corpus_type
+    update_corpus_type_taxonomy(
+        session, CorpusType, INTL_AGREEMENTS, get_unf3c_taxonomy()
+    )
+
+
+def downgrade():
+    # There is no way back
+    pass

--- a/db_client/alembic/versions/0036_add_event_type_to_unf3c_tax.py
+++ b/db_client/alembic/versions/0036_add_event_type_to_unf3c_tax.py
@@ -10,7 +10,8 @@ from alembic import op
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
 
-from db_client.data_migrations.taxonomy_unf3c import get_unf3c_taxonomy
+from db_client.data_migrations.taxonomy_unf3c import TAXONOMY_DATA, get_unf3c_taxonomy
+from db_client.utils import get_library_path
 
 # revision identifiers, used by Alembic.
 revision = "0036"
@@ -39,8 +40,22 @@ def upgrade():
 
     Base.prepare(autoload_with=bind)
     CorpusType = Base.classes.corpus_type
+
+    modified_unfccc_taxonomy = TAXONOMY_DATA
+    modified_unfccc_taxonomy = modified_unfccc_taxonomy.insert(
+        -1,
+        {
+            "key": "event_type",
+            "filename": f"{get_library_path()}/data_migrations/data/law_policy/event_type_data.json",
+            "file_key_path": "name",
+            "allow_blanks": True,
+        },
+    )
     update_corpus_type_taxonomy(
-        session, CorpusType, INTL_AGREEMENTS, get_unf3c_taxonomy()
+        session,
+        CorpusType,
+        INTL_AGREEMENTS,
+        get_unf3c_taxonomy(modified_unfccc_taxonomy),
     )
 
 

--- a/db_client/alembic/versions/0037_add_event_type_to_cclw_tax.py
+++ b/db_client/alembic/versions/0037_add_event_type_to_cclw_tax.py
@@ -1,0 +1,49 @@
+"""Add event_type to CCLW taxonomy.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2024-06-26 08:51:00.140151
+
+"""
+
+from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
+
+from db_client.data_migrations.taxonomy_cclw import get_cclw_taxonomy
+
+# revision identifiers, used by Alembic.
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+Base = automap_base()
+
+LAWS_AND_POLICIES = "Laws and Policies"
+
+
+def update_corpus_type_taxonomy(session, CorpusType, name, new_taxonomy):
+    # Get the exiting corpus type for Intl. agreements
+    cclw_ct = session.query(CorpusType).filter(CorpusType.name == name).one()
+    # update
+    cclw_ct.valid_metadata = new_taxonomy
+    # add
+    session.add(cclw_ct)
+    session.commit()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session: Session = Session(bind=bind)
+
+    Base.prepare(autoload_with=bind)
+    CorpusType = Base.classes.corpus_type
+    update_corpus_type_taxonomy(
+        session, CorpusType, LAWS_AND_POLICIES, get_cclw_taxonomy()
+    )
+
+
+def downgrade():
+    # There is no way back
+    pass

--- a/db_client/alembic/versions/0037_add_event_type_to_cclw_tax.py
+++ b/db_client/alembic/versions/0037_add_event_type_to_cclw_tax.py
@@ -10,7 +10,8 @@ from alembic import op
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
 
-from db_client.data_migrations.taxonomy_cclw import get_cclw_taxonomy
+from db_client.data_migrations.taxonomy_cclw import TAXONOMY_DATA, get_cclw_taxonomy
+from db_client.utils import get_library_path
 
 # revision identifiers, used by Alembic.
 revision = "0037"
@@ -39,8 +40,22 @@ def upgrade():
 
     Base.prepare(autoload_with=bind)
     CorpusType = Base.classes.corpus_type
+
+    modified_cclw_taxonomy = TAXONOMY_DATA
+    modified_cclw_taxonomy = modified_cclw_taxonomy.insert(
+        -1,
+        {
+            "key": "event_type",
+            "filename": f"{get_library_path()}/data_migrations/data/law_policy/event_type_data.json",
+            "file_key_path": "name",
+            "allow_blanks": True,
+        },
+    )
     update_corpus_type_taxonomy(
-        session, CorpusType, LAWS_AND_POLICIES, get_cclw_taxonomy()
+        session,
+        CorpusType,
+        LAWS_AND_POLICIES,
+        get_cclw_taxonomy(modified_cclw_taxonomy),
     )
 
 

--- a/db_client/data_migrations/taxonomy_cclw.py
+++ b/db_client/data_migrations/taxonomy_cclw.py
@@ -38,6 +38,12 @@ TAXONOMY_DATA = [
         "file_key_path": "name",
         "allow_blanks": True,
     },
+    {
+        "key": "event_type",
+        "filename": f"{get_library_path()}/data_migrations/data/law_policy/event_type_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
+    },
 ]
 
 

--- a/db_client/data_migrations/taxonomy_cclw.py
+++ b/db_client/data_migrations/taxonomy_cclw.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from db_client.data_migrations.taxonomy_utils import read_taxonomy_values
 from db_client.utils import get_library_path
 
@@ -38,17 +40,13 @@ TAXONOMY_DATA = [
         "file_key_path": "name",
         "allow_blanks": True,
     },
-    {
-        "key": "event_type",
-        "filename": f"{get_library_path()}/data_migrations/data/law_policy/event_type_data.json",
-        "file_key_path": "name",
-        "allow_blanks": True,
-    },
 ]
 
 
-def get_cclw_taxonomy():
-    taxonomy = read_taxonomy_values(TAXONOMY_DATA)
+def get_cclw_taxonomy(taxonomy_data: Optional[list[dict]] = None):
+    if taxonomy_data is None:
+        taxonomy_data = TAXONOMY_DATA
+    taxonomy = read_taxonomy_values(taxonomy_data)
 
     # Remove unwanted values for new taxonomy
     if "sector" in taxonomy:

--- a/db_client/data_migrations/taxonomy_unf3c.py
+++ b/db_client/data_migrations/taxonomy_unf3c.py
@@ -1,5 +1,6 @@
+from typing import Optional
+
 from db_client.data_migrations.taxonomy_utils import read_taxonomy_values
-from db_client.utils import get_library_path
 
 TAXONOMY_DATA = [
     {
@@ -13,14 +14,10 @@ TAXONOMY_DATA = [
         "allow_any": True,
         "allowed_values": [],
     },
-    {
-        "key": "event_type",
-        "filename": f"{get_library_path()}/data_migrations/data/law_policy/event_type_data.json",
-        "file_key_path": "name",
-        "allow_blanks": True,
-    },
 ]
 
 
-def get_unf3c_taxonomy():
-    return read_taxonomy_values(TAXONOMY_DATA)
+def get_unf3c_taxonomy(taxonomy_data: Optional[list[dict]] = None):
+    if taxonomy_data is None:
+        taxonomy_data = TAXONOMY_DATA
+    return read_taxonomy_values(taxonomy_data)

--- a/db_client/data_migrations/taxonomy_unf3c.py
+++ b/db_client/data_migrations/taxonomy_unf3c.py
@@ -1,4 +1,5 @@
 from db_client.data_migrations.taxonomy_utils import read_taxonomy_values
+from db_client.utils import get_library_path
 
 TAXONOMY_DATA = [
     {
@@ -11,6 +12,12 @@ TAXONOMY_DATA = [
         "allow_blanks": False,
         "allow_any": True,
         "allowed_values": [],
+    },
+    {
+        "key": "event_type",
+        "filename": f"{get_library_path()}/data_migrations/data/law_policy/event_type_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
     },
 ]
 

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -15,13 +15,16 @@ def validate_family_metadata(
 ) -> Optional[MetadataValidationErrors]:
     """Validates the Family's metadata against its Corpus' Taxonomy.
 
-    NOTE: That the taxonomy is also validated. This is because the Taxonomy is stored in the database and can be mutated independently of the Family's metadata.
+    NOTE: That the taxonomy is also validated. This is because the
+    Taxonomy is stored in the database and can be mutated independently
+    of the Family's metadata.
 
     :param Session db: The db connection session.
     :param Family family: The family to validate.
     :raises TypeError: If the Taxonomy is invalid.
     :raises ValidationError: If the Taxonomy values are invalid.
-    :return Optional[MetadataValidationResult]: A list of errors or None if the metadata is valid.
+    :return Optional[MetadataValidationResult]: A list of errors or None
+        if the metadata is valid.
     """
 
     # Retrieve the Taxonomy and the Family's metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.6.0"
+version = "3.6.1"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

Add "event-type" to the taxonomy of both CCLW and UNFCCC corpora with the values from the family_event_type table (using the already defined `event_type_data.json` file in the data migrations folder.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
