### PR TITLE
Driveby fixes

### DIFF
--- a/db_client/alembic/versions/0038_remove_familyeventtype_table.py
+++ b/db_client/alembic/versions/0038_remove_familyeventtype_table.py
@@ -6,14 +6,38 @@ Create Date: 2024-06-27 11:18:04.834908
 
 """
 
+import json
+
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from db_client.utils import get_library_path
+
+Base = automap_base()
 
 # revision identifiers, used by Alembic.
 revision = "0038"
 down_revision = "0037"
 branch_labels = None
 depends_on = None
+
+
+def _populate_event_type(db: Session) -> None:
+    """Populates the family_event_type table with pre-defined data."""
+
+    with open(
+        f"{get_library_path()}/data_migrations/data/law_policy/event_type_data.json"
+    ) as event_type_file:
+        event_type_data = json.load(event_type_file)
+
+        query = text(
+            "insert into family_event_type (name, description) values "
+            "(:name, :description)"
+        )
+        db.execute(query, params=event_type_data)
 
 
 def upgrade():
@@ -35,6 +59,14 @@ def downgrade():
         sa.Column("description", sa.TEXT(), autoincrement=False, nullable=False),
         sa.PrimaryKeyConstraint("name", name="pk_family_event_type"),
     )
+
+    # Repopulate table with initial event type names.
+    bind = op.get_bind()
+    Base.prepare(autoload_with=bind)
+
+    session = Session(bind=bind)
+    _populate_event_type(session)
+
     op.create_foreign_key(
         "fk_family_event__event_type_name__family_event_type",
         "family_event",

--- a/db_client/models/organisation/counters.py
+++ b/db_client/models/organisation/counters.py
@@ -62,7 +62,7 @@ class EntityCounter(Base):
     _get_and_increment = text(
         """
         WITH updated AS (
-        UPDATE entity_counter SET counter = COALESCE(0, counter) + 1
+        UPDATE entity_counter SET counter = COALESCE(counter, 0) + 1
         WHERE id = :id RETURNING counter
         )
         SELECT counter FROM updated;

--- a/db_client/models/organisation/counters.py
+++ b/db_client/models/organisation/counters.py
@@ -60,7 +60,7 @@ class EntityCounter(Base):
     _get_and_increment = text(
         """
         WITH updated AS (
-        UPDATE entity_counter SET counter = counter + 1
+        UPDATE entity_counter SET counter = COALESCE(0, counter) + 1
         WHERE id = :id RETURNING counter
         )
         SELECT counter FROM updated;
@@ -80,6 +80,11 @@ class EntityCounter(Base):
         """
         try:
             db = object_session(self)
+
+            if db is None:
+                _LOGGER.exception("When creating object session")
+                raise
+
             cmd = self._get_and_increment.bindparams(id=self.id)
             value = db.execute(cmd).scalar()
             db.commit()

--- a/db_client/models/organisation/counters.py
+++ b/db_client/models/organisation/counters.py
@@ -8,8 +8,10 @@ concept of "data source" is not yet implemented, see PDCT-431.
 
 import logging
 from enum import Enum
+from typing import Optional, cast
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.session import object_session
 from sqlalchemy.sql import text
 
@@ -79,14 +81,14 @@ class EntityCounter(Base):
         :return str: The next counter value.
         """
         try:
-            db = object_session(self)
+            db: Optional[Session] = object_session(self)
 
             if db is None:
                 _LOGGER.exception("When creating object session")
                 raise
 
             cmd = self._get_and_increment.bindparams(id=self.id)
-            value = db.execute(cmd).scalar()
+            value = cast(str, db.execute(cmd).scalar())
             db.commit()
             return value
         except:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.7.0"
+version = "3.7.1"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

- Fixed the downgrade for migration 0038
- Added a COALESCE on the EntityCounter counter column to prevent ID generation breaking

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
