### PR TITLE
Feature/pdct 1139 ensure document metadata is validated in db client

### DIFF
--- a/db_client/functions/__init__.py
+++ b/db_client/functions/__init__.py
@@ -4,10 +4,14 @@ from db_client.functions.dfce_helpers import (
     add_event,
     add_families,
 )
-from db_client.functions.metadata import validate_family_metadata
+from db_client.functions.metadata import (
+    validate_document_metadata,
+    validate_family_metadata,
+)
 
 __all__ = (
     "validate_family_metadata",
+    "validate_document_metadata",
     "add_collections",
     "add_families",
     "add_event",

--- a/db_client/functions/corpus_helpers.py
+++ b/db_client/functions/corpus_helpers.py
@@ -30,7 +30,9 @@ def get_taxonomy_from_corpus(db: Session, corpus_id: str) -> Optional[TaxonomyDa
     )
 
 
-def get_entity_specific_taxonomy(taxonomy, _entity_key: Optional[str] = None):
+def get_entity_specific_taxonomy(
+    taxonomy, _entity_key: Optional[str] = None
+) -> TaxonomyDataEntry:
     """Validates the Family's metadata against its Corpus' Taxonomy.
 
     :param dict taxonomy: The Corpus taxonomy to validate against.

--- a/db_client/functions/corpus_helpers.py
+++ b/db_client/functions/corpus_helpers.py
@@ -7,7 +7,10 @@ from db_client.models.organisation import Corpus, CorpusType
 
 _LOGGER = logging.getLogger(__name__)
 
-TaxonomyData = Mapping[str, Mapping[str, Union[dict, bool, str, Sequence[str]]]]
+TaxonomyDataEntry = Mapping[str, Union[bool, str, Sequence[str]]]
+TaxonomyData = Mapping[
+    str, Mapping[str, Union[TaxonomyDataEntry, bool, str, Sequence[str]]]
+]
 
 
 def get_taxonomy_from_corpus(db: Session, corpus_id: str) -> Optional[TaxonomyData]:

--- a/db_client/functions/corpus_helpers.py
+++ b/db_client/functions/corpus_helpers.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Mapping, Optional, Sequence, Union
+
+from sqlalchemy.orm import Session
+
+from db_client.models.organisation import Corpus, CorpusType
+
+_LOGGER = logging.getLogger(__name__)
+
+TaxonomyData = Mapping[str, Mapping[str, Union[dict, bool, str, Sequence[str]]]]
+
+
+def get_taxonomy_from_corpus(db: Session, corpus_id: str) -> Optional[TaxonomyData]:
+    """Get the taxonomy of a corpus.
+
+    :param Session db: The DB session to connect to.
+    :param str corpus_id: The corpus import ID we want to get the
+        taxonomy for.
+    :return Optional[TaxonomyData]: The taxonomy of the given corpus or
+        None.
+    """
+    return (
+        db.query(CorpusType.valid_metadata)
+        .join(Corpus, Corpus.corpus_type_name == CorpusType.name)
+        .filter(Corpus.import_id == corpus_id)
+        .scalar()
+    )
+
+
+def get_entity_specific_taxonomy(taxonomy, _entity_key: Optional[str] = None):
+    """Validates the Family's metadata against its Corpus' Taxonomy.
+
+    :param dict taxonomy: The Corpus taxonomy to validate against.
+    :param str _entity_key: The family metadata to validate.
+    :raises TypeError: If the entity specific taxonomy key isn't present.
+    :return dict: The entity specific taxonomy if found or the passed
+        taxonomy.
+    """
+    if taxonomy is not None and _entity_key is not None:
+        if _entity_key not in taxonomy.keys():
+            raise TypeError(f"Cannot find {_entity_key} taxonomy data in database")
+        taxonomy = taxonomy[_entity_key]
+    return taxonomy

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -8,7 +8,10 @@ from db_client.functions.corpus_helpers import (
     get_entity_specific_taxonomy,
     get_taxonomy_from_corpus,
 )
-from db_client.models.dfce.taxonomy_entry import TaxonomyEntry
+from db_client.models.dfce.taxonomy_entry import (
+    EntitySpecificTaxonomyKeys,
+    TaxonomyEntry,
+)
 
 MetadataValidationErrors = Sequence[str]
 
@@ -37,7 +40,13 @@ def validate_family_metadata(
     # TODO: When we move the family schema under _family we can consolidate these entity
     # specific validation functions.
     taxonomy = {
-        k: v for (k, v) in taxonomy.items() if k not in ["_document", "event_type"]
+        k: v
+        for (k, v) in taxonomy.items()
+        if k
+        not in [
+            EntitySpecificTaxonomyKeys.DOCUMENT.value,
+            EntitySpecificTaxonomyKeys.EVENT.value,
+        ]
     }
     return validate_metadata_against_taxonomy(taxonomy, metadata)
 
@@ -65,7 +74,9 @@ def validate_document_metadata(
     # Make sure we only get the document taxonomy keys.
     # TODO: When we move the family schema under _family we can consolidate these entity
     # specific validation functions.
-    taxonomy = get_entity_specific_taxonomy(taxonomy, "_document")
+    taxonomy = get_entity_specific_taxonomy(
+        taxonomy, EntitySpecificTaxonomyKeys.DOCUMENT.value
+    )
     return validate_metadata_against_taxonomy(taxonomy, metadata)
 
 

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -2,16 +2,17 @@ from typing import Mapping, Optional, Sequence
 
 from sqlalchemy.orm import Session
 
-from db_client.models.dfce.family import Family, FamilyCorpus
-from db_client.models.dfce.metadata import FamilyMetadata
+from db_client.functions.corpus_helpers import (
+    get_entity_specific_taxonomy,
+    get_taxonomy_from_corpus,
+)
 from db_client.models.dfce.taxonomy_entry import TaxonomyEntry
-from db_client.models.organisation.corpus import Corpus, CorpusType
 
 MetadataValidationErrors = Sequence[str]
 
 
 def validate_family_metadata(
-    db: Session, family: Family
+    db: Session, corpus_id: str, metadata
 ) -> Optional[MetadataValidationErrors]:
     """Validates the Family's metadata against its Corpus' Taxonomy.
 
@@ -19,36 +20,69 @@ def validate_family_metadata(
     Taxonomy is stored in the database and can be mutated independently
     of the Family's metadata.
 
-    :param Session db: The db connection session.
-    :param Family family: The family to validate.
-    :raises TypeError: If the Taxonomy is invalid.
-    :raises ValidationError: If the Taxonomy values are invalid.
+    :param Session db: The Session to query.
+    :param str corpus_id: The corpus import ID to retrieve the taxonomy
+        for.
+    :param dict metadata: The family metadata to validate.
     :return Optional[MetadataValidationResult]: A list of errors or None
         if the metadata is valid.
     """
+    taxonomy = get_taxonomy_from_corpus(db, corpus_id)
+    if taxonomy is None:
+        raise TypeError("No taxonomy found for corpus")
 
-    # Retrieve the Taxonomy and the Family's metadata
-    corpus_type, metadata = (
-        db.query(CorpusType, FamilyMetadata)
-        .join(Corpus, CorpusType.name == Corpus.corpus_type_name)
-        .join(FamilyCorpus, FamilyCorpus.corpus_import_id == Corpus.import_id)
-        .join(Family, family.import_id == FamilyCorpus.family_import_id)
-        .join(FamilyMetadata, FamilyMetadata.family_import_id == family.import_id)
-        .filter(Family.import_id == family.import_id)
-        .one()
-    )
-    taxonomy = corpus_type.valid_metadata
+    # Make sure we only get the family taxonomy keys.
+    # TODO: When we move the family schema under _family we can consolidate these entity
+    # specific validation functions.
+    taxonomy = {
+        k: v for (k, v) in taxonomy.items() if k not in ["_document", "event_type"]
+    }
+    return _validate_metadata_against_taxonomy(taxonomy, metadata)
+
+
+def validate_document_metadata(
+    db, corpus_id: str, metadata
+) -> Optional[MetadataValidationErrors]:
+    """Validates the Document's metadata against its Corpus' Taxonomy.
+
+    NOTE: That the taxonomy is also validated. This is because the
+    Taxonomy is stored in the database and can be mutated independently
+    of the Family's metadata.
+
+    :param Session db: The Session to query.
+    :param str corpus_id: The corpus import ID to retrieve the taxonomy
+        for.
+    :param dict metadata: The document metadata to validate.
+    :return Optional[MetadataValidationResult]: A list of errors or None
+        if the metadata is valid.
+    """
+    taxonomy = get_taxonomy_from_corpus(db, corpus_id)
+    if taxonomy is None:
+        raise TypeError("No taxonomy found for corpus")
+
+    # Make sure we only get the document taxonomy keys.
+    # TODO: When we move the family schema under _family we can consolidate these entity
+    # specific validation functions.
+    taxonomy = get_entity_specific_taxonomy(taxonomy, "_document")
+    return _validate_metadata_against_taxonomy(taxonomy, metadata)
+
+
+def _validate_metadata_against_taxonomy(taxonomy, metadata):
+    """Build the Corpus taxonomy for the entity & validate against it.
+
+    :param dict taxonomy: The Corpus taxonomy to validate against.
+    :param dict metadata: The metadata to validate.
+    :raises TypeError: If the Taxonomy is invalid.
+    :return Optional[MetadataValidationResult]: A list of errors or None
+        if the metadata is valid.
+    """
     try:
         taxonomy_entries = build_valid_taxonomy(taxonomy)
     except TypeError as e:
         # Wrap any TypeError in a more general error
         raise TypeError("Bad Taxonomy data in database") from e
 
-    family_metadata = metadata.value
-
-    errors = validate_metadata(taxonomy_entries, family_metadata)
-
-    # TODO: validate family_metadata against taxonomy
+    errors = validate_metadata(taxonomy_entries, metadata)
     return errors if len(errors) > 0 else None
 
 
@@ -57,9 +91,11 @@ def validate_metadata(
 ) -> MetadataValidationErrors:
     """Validates the metadata against the taxonomy.
 
-    :param _type_ taxonomy_entries: The built entries from the CorpusType.valid_metadata.
+    :param _type_ taxonomy_entries: The built entries from the
+        CorpusType.valid_metadata.
     :param _type_ metadata: The metadata to validate.
-    :return MetadataValidationErrors: a list of errors if the metadata is invalid.
+    :return MetadataValidationErrors: a list of errors if the metadata
+        is invalid.
     """
     errors = []
     metadata_keys = set(metadata.keys())
@@ -94,13 +130,20 @@ def validate_metadata(
 
 
 def build_valid_taxonomy(taxonomy: Mapping) -> Mapping[str, TaxonomyEntry]:
-    """Takes the taxonomy from the database and builds a dictionary of TaxonomyEntry objects, used for validation.
+    """Build valid taxonomy used to validate metadata against.
 
-    :param Sequence taxonomy: From the database model CorpusType.valid_metadata
+    Takes the taxonomy from the database and builds a dictionary of
+    TaxonomyEntry objects, used for validation.
+
+    :param Sequence taxonomy: From the database model
+        CorpusType.valid_metadata and potentially filtered by entity key
     :raises TypeError: If the taxonomy is not a list.
     :raises TypeError: If the taxonomy entry is not a dictionary.
-    :raises TypeError: If the values within the taxonomy entry are not dictionaries.
-    :return Mapping[str, TaxonomyEntry]: a dictionary of TaxonomyEntry objects (contains property constraints) keyed by the taxonomy entry name (property).
+    :raises TypeError: If the values within the taxonomy entry are not
+        dictionaries.
+    :return Mapping[str, TaxonomyEntry]: a dictionary of TaxonomyEntry
+        objects (contains property constraints) keyed by the taxonomy
+        entry name (property).
     """
     if not isinstance(taxonomy, dict):
         raise TypeError("Taxonomy is not a dictionary")

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -1,8 +1,10 @@
-from typing import Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence, Union
 
 from sqlalchemy.orm import Session
 
 from db_client.functions.corpus_helpers import (
+    TaxonomyData,
+    TaxonomyDataEntry,
     get_entity_specific_taxonomy,
     get_taxonomy_from_corpus,
 )
@@ -12,7 +14,7 @@ MetadataValidationErrors = Sequence[str]
 
 
 def validate_family_metadata(
-    db: Session, corpus_id: str, metadata
+    db: Session, corpus_id: str, metadata: TaxonomyDataEntry
 ) -> Optional[MetadataValidationErrors]:
     """Validates the Family's metadata against its Corpus' Taxonomy.
 
@@ -37,11 +39,11 @@ def validate_family_metadata(
     taxonomy = {
         k: v for (k, v) in taxonomy.items() if k not in ["_document", "event_type"]
     }
-    return _validate_metadata_against_taxonomy(taxonomy, metadata)
+    return validate_metadata_against_taxonomy(taxonomy, metadata)
 
 
 def validate_document_metadata(
-    db, corpus_id: str, metadata
+    db, corpus_id: str, metadata: TaxonomyDataEntry
 ) -> Optional[MetadataValidationErrors]:
     """Validates the Document's metadata against its Corpus' Taxonomy.
 
@@ -52,7 +54,7 @@ def validate_document_metadata(
     :param Session db: The Session to query.
     :param str corpus_id: The corpus import ID to retrieve the taxonomy
         for.
-    :param dict metadata: The document metadata to validate.
+    :param TaxonomyDataEntry metadata: The document metadata to validate.
     :return Optional[MetadataValidationResult]: A list of errors or None
         if the metadata is valid.
     """
@@ -64,14 +66,16 @@ def validate_document_metadata(
     # TODO: When we move the family schema under _family we can consolidate these entity
     # specific validation functions.
     taxonomy = get_entity_specific_taxonomy(taxonomy, "_document")
-    return _validate_metadata_against_taxonomy(taxonomy, metadata)
+    return validate_metadata_against_taxonomy(taxonomy, metadata)
 
 
-def _validate_metadata_against_taxonomy(taxonomy, metadata):
+def validate_metadata_against_taxonomy(
+    taxonomy: Union[TaxonomyData, TaxonomyDataEntry], metadata: TaxonomyDataEntry
+) -> Optional[MetadataValidationErrors]:
     """Build the Corpus taxonomy for the entity & validate against it.
 
-    :param dict taxonomy: The Corpus taxonomy to validate against.
-    :param dict metadata: The metadata to validate.
+    :param TaxonomyDataEntry taxonomy: The Corpus taxonomy to validate against.
+    :param TaxonomyDataEntry metadata: The metadata to validate.
     :raises TypeError: If the Taxonomy is invalid.
     :return Optional[MetadataValidationResult]: A list of errors or None
         if the metadata is valid.

--- a/db_client/models/dfce/taxonomy_entry.py
+++ b/db_client/models/dfce/taxonomy_entry.py
@@ -19,10 +19,18 @@ The fields define how metadata gets validated:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 
+from enum import Enum
 from typing import Mapping, Sequence
 
 from pydantic.config import ConfigDict
 from pydantic.dataclasses import dataclass as pydantic_dataclass
+
+
+class EntitySpecificTaxonomyKeys(str, Enum):
+    """The entity specific taxonomy keys."""
+
+    DOCUMENT = "_document"
+    EVENT = "event_type"
 
 
 @pydantic_dataclass(config=ConfigDict(validate_assignment=True, extra="forbid"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.0"
+version = "3.8.1"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/functions/test_get_entity_specific_taxonomy.py
+++ b/tests/functions/test_get_entity_specific_taxonomy.py
@@ -1,0 +1,57 @@
+import pytest
+
+from db_client.functions.metadata import get_entity_specific_taxonomy
+
+EXPECTED_BAD_TAXONOMY = "Bad Taxonomy data in database"
+
+
+def test_original_taxonomy_is_none():
+    assert get_entity_specific_taxonomy(None) is None
+
+
+def test_original_taxonomy_is_not_none_and_no_entity_key_given():
+    taxonomy = {
+        "animals": {
+            "allow_blanks": True,
+            "allowed_values": [],
+            "allow_any": True,
+        },
+    }
+    assert get_entity_specific_taxonomy(taxonomy) == taxonomy
+
+
+def test_original_taxonomy_is_not_none_and_entity_key_given_but_not_valid():
+    taxonomy = {
+        "animals": {
+            "allow_blanks": True,
+            "allowed_values": [],
+            "allow_any": True,
+        },
+    }
+    with pytest.raises(TypeError) as e:
+        get_entity_specific_taxonomy(taxonomy, "fruits")
+    assert str(e.value) == "Cannot find fruits taxonomy data in database"
+
+
+def test_original_taxonomy_is_not_none_and_entity_key_given_and_valid():
+    foods_taxonomy = {
+        "fruits": {
+            "allow_blanks": True,
+            "allowed_values": [],
+            "allow_any": True,
+        },
+        "vegetables": {
+            "allow_blanks": False,
+            "allowed_values": ["leek", "carrot", "potato"],
+            "allow_any": False,
+        },
+    }
+    taxonomy = {
+        "animals": {
+            "allow_blanks": True,
+            "allowed_values": [],
+            "allow_any": True,
+        },
+        "foods": foods_taxonomy,
+    }
+    assert get_entity_specific_taxonomy(taxonomy, "foods") == foods_taxonomy

--- a/tests/functions/test_metadata.py
+++ b/tests/functions/test_metadata.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 from pytest_mock_resources import create_postgres_fixture
 
-from db_client.functions.metadata import validate_family_metadata
+from db_client.functions.metadata import _validate_metadata_against_taxonomy
 from db_client.models.base import Base
 from tests.functions.helpers import family_build, metadata_build
 
@@ -13,18 +13,17 @@ EXPECTED_BAD_TAXONOMY = "Bad Taxonomy data in database"
 
 
 def setup_test(db, taxonomy, metadata):
-    org, corpus, corpus_type = metadata_build(db, taxonomy)
-    family = family_build(db, org, corpus, metadata)
-    return org, family
+    org, corpus, _ = metadata_build(db, taxonomy)
+    family_build(db, org, corpus, metadata)
 
 
 def test_validation_fails_when_taxonomy_bad(db):
-    _, family = setup_test(
-        db, {"one": "two", "three": "four"}, {"metadata": "anything"}
-    )
+    taxonomy = {"one": "two", "three": "four"}
+    metadata = {"metadata": "anything"}
+    setup_test(db, taxonomy, metadata)
 
     with pytest.raises(TypeError) as e:
-        validate_family_metadata(db, family)
+        _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert str(e.value) == EXPECTED_BAD_TAXONOMY
     inner = e.value.__cause__
@@ -33,17 +32,15 @@ def test_validation_fails_when_taxonomy_bad(db):
 
 
 def test_validation_fails_when_taxonomy_missing_allow_blanks(db):
-    _, family = setup_test(
-        db,
-        {
-            "author_type": {
-                "allowed_values": ["Party", "Non-Party"],
-            }
-        },
-        {"metadata": "anything"},
-    )
+    taxonomy = {
+        "author_type": {
+            "allowed_values": ["Party", "Non-Party"],
+        }
+    }
+    metadata = {"metadata": "anything"}
+    setup_test(db, taxonomy, metadata)
     with pytest.raises(ValidationError) as e:
-        validate_family_metadata(db, family)
+        _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert len(e.value.errors()) == 1
     error = e.value.errors()[0]
@@ -53,17 +50,15 @@ def test_validation_fails_when_taxonomy_missing_allow_blanks(db):
 
 
 def test_validation_fails_when_taxonomy_missing_allowed_values(db):
-    _, family = setup_test(
-        db,
-        {
-            "author_type": {
-                "allow_blanks": False,
-            }
-        },
-        {"metadata": "anything"},
-    )
+    taxonomy = {
+        "author_type": {
+            "allow_blanks": False,
+        }
+    }
+    metadata = {"metadata": "anything"}
+    setup_test(db, taxonomy, metadata)
     with pytest.raises(ValidationError) as e:
-        validate_family_metadata(db, family)
+        _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert len(e.value.errors()) == 1
     error = e.value.errors()[0]
@@ -73,19 +68,17 @@ def test_validation_fails_when_taxonomy_missing_allowed_values(db):
 
 
 def test_validation_fails_when_taxonomy_has_extra(db):
-    _, family = setup_test(
-        db,
-        {
-            "author_type": {
-                "allow_blanks": False,
-                "allowed_values": ["Party", "Non-Party"],
-                "extra": "field",
-            }
-        },
-        {"metadata": "anything"},
-    )
+    taxonomy = {
+        "author_type": {
+            "allow_blanks": False,
+            "allowed_values": ["Party", "Non-Party"],
+            "extra": "field",
+        }
+    }
+    metadata = {"metadata": "anything"}
+    setup_test(db, taxonomy, metadata)
     with pytest.raises(ValidationError) as e:
-        validate_family_metadata(db, family)
+        _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert len(e.value.errors()) == 1
     error = e.value.errors()[0]
@@ -95,40 +88,36 @@ def test_validation_fails_when_taxonomy_has_extra(db):
 
 
 def test_validation_when_good(db):
-    _, family = setup_test(
-        db,
-        {
-            "author_type": {
-                "allow_blanks": False,
-                "allowed_values": ["Party", "Non-Party"],
-            },
-            "animals": {
-                "allow_blanks": True,
-                "allowed_values": [],
-                "allow_any": True,
-            },
+    taxonomy = {
+        "author_type": {
+            "allow_blanks": False,
+            "allowed_values": ["Party", "Non-Party"],
         },
-        {"author_type": ["Party"], "animals": ["sheep"]},
-    )
+        "animals": {
+            "allow_blanks": True,
+            "allowed_values": [],
+            "allow_any": True,
+        },
+    }
+    metadata = {"author_type": ["Party"], "animals": ["sheep"]}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None
 
 
 def test_validation_errors_on_extra_keys(db):
-    _, family = setup_test(
-        db,
-        {
-            "author_type": {
-                "allow_blanks": False,
-                "allowed_values": ["Party", "Non-Party"],
-            }
-        },
-        {"author_type": ["Party"], "animals": ["sheep"]},
-    )
+    taxonomy = {
+        "author_type": {
+            "allow_blanks": False,
+            "allowed_values": ["Party", "Non-Party"],
+        }
+    }
+    metadata = {"author_type": ["Party"], "animals": ["sheep"]}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -136,25 +125,21 @@ def test_validation_errors_on_extra_keys(db):
 
 
 def test_validation_errors_on_missing_keys(db):
-    _, family = setup_test(
-        db,
-        {
-            "author_type": {
-                "allow_blanks": False,
-                "allowed_values": ["Party", "Non-Party"],
-            },
-            "animals": {
-                "allow_blanks": True,
-                "allowed_values": [],
-                "allow_any": True,
-            },
+    taxonomy = {
+        "author_type": {
+            "allow_blanks": False,
+            "allowed_values": ["Party", "Non-Party"],
         },
-        {
-            "author_type": ["Party"],
+        "animals": {
+            "allow_blanks": True,
+            "allowed_values": [],
+            "allow_any": True,
         },
-    )
+    }
+    metadata = {"author_type": ["Party"]}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -162,18 +147,16 @@ def test_validation_errors_on_missing_keys(db):
 
 
 def test_validation_errors_on_blanks(db):
-    _, family = setup_test(
-        db,
-        {
-            "animals": {
-                "allow_blanks": False,
-                "allowed_values": [],
-            },
+    taxonomy = {
+        "animals": {
+            "allow_blanks": False,
+            "allowed_values": [],
         },
-        {"animals": []},
-    )
+    }
+    metadata = {"animals": []}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -181,35 +164,31 @@ def test_validation_errors_on_blanks(db):
 
 
 def test_validation_allows_blanks(db):
-    _, family = setup_test(
-        db,
-        {
-            "animals": {
-                "allow_blanks": True,
-                "allowed_values": [],
-            },
+    taxonomy = {
+        "animals": {
+            "allow_blanks": True,
+            "allowed_values": [],
         },
-        {"animals": []},
-    )
+    }
+    metadata = {"animals": []}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None
 
 
 def test_validation_errors_on_disallowed_values(db):
-    _, family = setup_test(
-        db,
-        {
-            "animals": {
-                "allow_blanks": False,
-                "allowed_values": ["sheep", "goat"],
-            },
+    taxonomy = {
+        "animals": {
+            "allow_blanks": False,
+            "allowed_values": ["sheep", "goat"],
         },
-        {"animals": ["cat"]},
-    )
+    }
+    metadata = {"animals": ["cat"]}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -217,35 +196,31 @@ def test_validation_errors_on_disallowed_values(db):
 
 
 def test_validation_allows_values(db):
-    _, family = setup_test(
-        db,
-        {
-            "animals": {
-                "allow_blanks": False,
-                "allowed_values": ["sheep", "goat"],
-            },
+    taxonomy = {
+        "animals": {
+            "allow_blanks": False,
+            "allowed_values": ["sheep", "goat"],
         },
-        {"animals": ["sheep"]},
-    )
+    }
+    metadata = {"animals": ["sheep"]}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None
 
 
 def test_validation_allows_any(db):
-    _, family = setup_test(
-        db,
-        {
-            "animals": {
-                "allow_blanks": False,
-                "allowed_values": ["sheep", "goat"],
-                "allow_any": True,
-            },
+    taxonomy = {
+        "animals": {
+            "allow_blanks": False,
+            "allowed_values": ["sheep", "goat"],
+            "allow_any": True,
         },
-        {"animals": ["cat"]},
-    )
+    }
+    metadata = {"animals": ["cat"]}
+    setup_test(db, taxonomy, metadata)
 
-    errors = validate_family_metadata(db, family)
+    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None

--- a/tests/functions/test_metadata.py
+++ b/tests/functions/test_metadata.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 from pytest_mock_resources import create_postgres_fixture
 
-from db_client.functions.metadata import _validate_metadata_against_taxonomy
+from db_client.functions.metadata import validate_metadata_against_taxonomy
 from db_client.models.base import Base
 from tests.functions.helpers import family_build, metadata_build
 
@@ -23,7 +23,7 @@ def test_validation_fails_when_taxonomy_bad(db):
     setup_test(db, taxonomy, metadata)
 
     with pytest.raises(TypeError) as e:
-        _validate_metadata_against_taxonomy(taxonomy, metadata)
+        validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert str(e.value) == EXPECTED_BAD_TAXONOMY
     inner = e.value.__cause__
@@ -40,7 +40,7 @@ def test_validation_fails_when_taxonomy_missing_allow_blanks(db):
     metadata = {"metadata": "anything"}
     setup_test(db, taxonomy, metadata)
     with pytest.raises(ValidationError) as e:
-        _validate_metadata_against_taxonomy(taxonomy, metadata)
+        validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert len(e.value.errors()) == 1
     error = e.value.errors()[0]
@@ -58,7 +58,7 @@ def test_validation_fails_when_taxonomy_missing_allowed_values(db):
     metadata = {"metadata": "anything"}
     setup_test(db, taxonomy, metadata)
     with pytest.raises(ValidationError) as e:
-        _validate_metadata_against_taxonomy(taxonomy, metadata)
+        validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert len(e.value.errors()) == 1
     error = e.value.errors()[0]
@@ -78,7 +78,7 @@ def test_validation_fails_when_taxonomy_has_extra(db):
     metadata = {"metadata": "anything"}
     setup_test(db, taxonomy, metadata)
     with pytest.raises(ValidationError) as e:
-        _validate_metadata_against_taxonomy(taxonomy, metadata)
+        validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert len(e.value.errors()) == 1
     error = e.value.errors()[0]
@@ -102,7 +102,7 @@ def test_validation_when_good(db):
     metadata = {"author_type": ["Party"], "animals": ["sheep"]}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None
 
@@ -117,7 +117,7 @@ def test_validation_errors_on_extra_keys(db):
     metadata = {"author_type": ["Party"], "animals": ["sheep"]}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -139,7 +139,7 @@ def test_validation_errors_on_missing_keys(db):
     metadata = {"author_type": ["Party"]}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -156,7 +156,7 @@ def test_validation_errors_on_blanks(db):
     metadata = {"animals": []}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -173,7 +173,7 @@ def test_validation_allows_blanks(db):
     metadata = {"animals": []}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None
 
@@ -188,7 +188,7 @@ def test_validation_errors_on_disallowed_values(db):
     metadata = {"animals": ["cat"]}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is not None
     assert len(errors) == 1
@@ -205,7 +205,7 @@ def test_validation_allows_values(db):
     metadata = {"animals": ["sheep"]}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None
 
@@ -221,6 +221,6 @@ def test_validation_allows_any(db):
     metadata = {"animals": ["cat"]}
     setup_test(db, taxonomy, metadata)
 
-    errors = _validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None


### PR DESCRIPTION
# What's changed

- Validate document metadata in db_client
- Fix family metadata validation function in db_client
- Test core validation functionality and get_entity_specific_taxonomy rather than testing the validate_family_metadata and validate_document_metadata

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
