### PR TITLE
Feature/pdct 1245 copy document role into family doc metadata column object

### DIFF
--- a/db_client/alembic/versions/0045_copy_document_role_into_metadata.py
+++ b/db_client/alembic/versions/0045_copy_document_role_into_metadata.py
@@ -1,0 +1,33 @@
+"""Copy document role into metadata.
+
+Revision ID: 0045
+Revises: 0043
+Create Date: 2024-07-09 14:01:33.721363
+
+"""
+
+from alembic import op
+
+revision = "0045"
+down_revision = "0044"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """UPDATE family_document
+SET valid_metadata = subquery.metadata
+FROM (
+    SELECT import_id, jsonb_build_object('role', jsonb_agg(document_role)) AS metadata
+    FROM family_document
+    WHERE valid_metadata IS NULL
+    GROUP BY import_id
+) AS subquery
+WHERE family_document.import_id = subquery.import_id
+AND family_document.valid_metadata IS NULL"""
+    )
+
+
+def downgrade():
+    pass  # No way back

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.4"
+version = "3.8.5"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

Copy document role into family doc metadata column object in format 

```
{
  "role": [ document_role ]
}
```

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
