### PR TITLE
Feature/pdct 1245 make family document metadata column not nullable 

### DIFF
--- a/db_client/alembic/versions/0045_copy_document_role_into_metadata.py
+++ b/db_client/alembic/versions/0045_copy_document_role_into_metadata.py
@@ -6,7 +6,9 @@ Create Date: 2024-07-09 14:01:33.721363
 
 """
 
+import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0045"
 down_revision = "0044"
@@ -26,6 +28,12 @@ FROM (
 ) AS subquery
 WHERE family_document.import_id = subquery.import_id
 AND family_document.valid_metadata IS NULL"""
+    )
+    op.alter_column(
+        "family_document",
+        "valid_metadata",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=False,
     )
 
 

--- a/db_client/models/dfce/family.py
+++ b/db_client/models/dfce/family.py
@@ -230,7 +230,7 @@ class FamilyDocument(Base):
         lazy="joined",
     )
 
-    valid_metadata = sa.Column(postgresql.JSONB)
+    valid_metadata = sa.Column(postgresql.JSONB, nullable=False)
 
 
 class Slug(Base):


### PR DESCRIPTION
# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
