### PR TITLE
Pdct 1095 move document type to taxonomy

### DIFF
--- a/db_client/alembic/versions/0047_add_document_type_to__document_unfccc_taxonomy.py
+++ b/db_client/alembic/versions/0047_add_document_type_to__document_unfccc_taxonomy.py
@@ -1,0 +1,92 @@
+"""Add document type to _document UNFCCC taxonomy
+
+Revision ID: 0047
+Revises: 0046
+Create Date: 2024-07-10 15:56:43.713717
+
+"""
+
+from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
+
+from db_client.data_migrations.taxonomy_utils import read_taxonomy_values
+from db_client.utils import get_library_path
+
+# revision identifiers, used by Alembic.
+revision = "0047"
+down_revision = "0046"
+branch_labels = None
+depends_on = None
+
+Base = automap_base()
+
+
+INTL_AGREEMENTS = "Intl. agreements"
+
+TAXONOMY_DATA = [
+    {
+        "key": "author_type",
+        "allow_blanks": False,
+        "allowed_values": ["Party", "Non-Party"],
+    },
+    {
+        "key": "author",
+        "allow_blanks": False,
+        "allow_any": True,
+        "allowed_values": [],
+    },
+    {
+        "key": "event_type",
+        "filename": f"{get_library_path()}/alembic/versions/data/0047/event_type_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "_document",
+        "taxonomy": [
+            {
+                "key": "role",
+                "filename": f"{get_library_path()}/alembic/versions/data/0047/document_role_data.json",
+                "file_key_path": "name",
+                "allow_blanks": False,
+            },
+            {
+                "key": "type",
+                "filename": f"{get_library_path()}/alembic/versions/data/0047/new_document_type_data.json",
+                "file_key_path": "name",
+                "allow_blanks": False,
+            },
+        ],
+    },
+]
+
+
+def get_unf3c_taxonomy():
+    return read_taxonomy_values(TAXONOMY_DATA)
+
+
+def update_corpus_type_taxonomy(session, CorpusType, name, new_taxonomy):
+    # Get the exiting corpus type for Intl. agreements
+    unfccc_ct = session.query(CorpusType).filter(CorpusType.name == name).one()
+    # update
+    unfccc_ct.valid_metadata = new_taxonomy
+    # add
+    session.add(unfccc_ct)
+    session.commit()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session: Session = Session(bind=bind)
+
+    Base.prepare(autoload_with=bind)
+    CorpusType = Base.classes.corpus_type
+
+    update_corpus_type_taxonomy(
+        session, CorpusType, INTL_AGREEMENTS, get_unf3c_taxonomy()
+    )
+
+
+def downgrade():
+    pass

--- a/db_client/alembic/versions/0048_add_document_type_to__document_cclw_.py
+++ b/db_client/alembic/versions/0048_add_document_type_to__document_cclw_.py
@@ -1,0 +1,131 @@
+"""Add document type to _document CCLW taxonomy
+
+Revision ID: 0048
+Revises: 0047
+Create Date: 2024-07-10 16:16:00.648776
+
+"""
+
+from alembic import op
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
+
+from db_client.data_migrations.taxonomy_utils import read_taxonomy_values
+from db_client.utils import get_library_path
+
+# revision identifiers, used by Alembic.
+revision = "0048"
+down_revision = "0047"
+branch_labels = None
+depends_on = None
+
+
+Base = automap_base()
+
+LAWS_AND_POLICIES = "Laws and Policies"
+
+TAXONOMY_DATA = [
+    {
+        "key": "topic",
+        "filename": f"{get_library_path()}/alembic/versions/data/0048/topic_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "sector",
+        "filename": f"{get_library_path()}/alembic/versions/data/0048/sector_data.json",
+        "file_key_path": "node.name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "keyword",
+        "filename": f"{get_library_path()}/alembic/versions/data/0048/keyword_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "instrument",
+        "filename": f"{get_library_path()}/alembic/versions/data/0048/instrument_data.json",
+        "file_key_path": "node.name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "hazard",
+        "filename": f"{get_library_path()}/alembic/versions/data/0048/hazard_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "framework",
+        "filename": f"{get_library_path()}/alembic/versions/data/0048/framework_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "event_type",
+        "filename": f"{get_library_path()}/alembic/versions/data/0048/event_type_data.json",
+        "file_key_path": "name",
+        "allow_blanks": True,
+    },
+    {
+        "key": "_document",
+        "taxonomy": [
+            {
+                "key": "role",
+                "filename": f"{get_library_path()}/alembic/versions/data/0048/document_role_data.json",
+                "file_key_path": "name",
+                "allow_blanks": False,
+            },
+            {
+                "key": "type",
+                "filename": f"{get_library_path()}/alembic/versions/data/0048/new_document_type_data.json",
+                "file_key_path": "name",
+                "allow_blanks": False,
+            },
+        ],
+    },
+]
+
+
+def get_cclw_taxonomy():
+    taxonomy = read_taxonomy_values(TAXONOMY_DATA)
+
+    # Remove unwanted values for new taxonomy
+    if "sector" in taxonomy:
+        sectors = taxonomy["sector"]["allowed_values"]
+        if "Transportation" in sectors:
+            taxonomy["sector"]["allowed_values"] = [
+                s for s in sectors if s != "Transportation"
+            ]
+
+    return taxonomy
+
+
+def update_corpus_type_taxonomy(session, CorpusType, name, new_taxonomy):
+    # Get the exiting corpus type for Intl. agreements
+    cclw_ct = session.query(CorpusType).filter(CorpusType.name == name).one()
+    # update
+    cclw_ct.valid_metadata = new_taxonomy
+    # add
+    session.add(cclw_ct)
+    session.commit()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session: Session = Session(bind=bind)
+
+    Base.prepare(autoload_with=bind)
+    CorpusType = Base.classes.corpus_type
+
+    update_corpus_type_taxonomy(
+        session,
+        CorpusType,
+        LAWS_AND_POLICIES,
+        get_cclw_taxonomy(),
+    )
+
+
+def downgrade():
+    # There is no way back
+    pass

--- a/db_client/alembic/versions/data/0047/document_role_data.json
+++ b/db_client/alembic/versions/data/0047/document_role_data.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "MAIN",
+    "description": "MAIN"
+  },
+  {
+    "name": "AMENDMENT",
+    "description": "AMENDMENT"
+  },
+  {
+    "name": "SUPPORTING LEGISLATION",
+    "description": "SUPPORTING LEGISLATION"
+  },
+  {
+    "name": "SUMMARY",
+    "description": "SUMMARY"
+  },
+  {
+    "name": "PREVIOUS VERSION",
+    "description": "PREVIOUS VERSION"
+  },
+  {
+    "name": "ANNEX",
+    "description": "ANNEX"
+  },
+  {
+    "name": "SUPPORTING DOCUMENTATION",
+    "description": "SUPPORTING DOCUMENTATION"
+  },
+  {
+    "name": "INFORMATION WEBPAGE",
+    "description": "INFORMATION WEBPAGE"
+  },
+  {
+    "name": "PRESS RELEASE",
+    "description": "PRESS RELEASE"
+  },
+  {
+    "name": "DOCUMENT(S) STORED ON WEBPAGE",
+    "description": "DOCUMENT(S) STORED ON WEBPAGE"
+  }
+]

--- a/db_client/alembic/versions/data/0047/event_type_data.json
+++ b/db_client/alembic/versions/data/0047/event_type_data.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "Amended",
+    "description": "Amended Event"
+  },
+  {
+    "name": "Appealed",
+    "description": "Appealed Event"
+  },
+  {
+    "name": "Closed",
+    "description": "Closed Event"
+  },
+  {
+    "name": "Declaration Of Climate Emergency",
+    "description": "Declaration Of Climate Emergency Event"
+  },
+  {
+    "name": "Dismissed",
+    "description": "Dismissed Event"
+  },
+  {
+    "name": "Entered Into Force",
+    "description": "Entered Into Force Event"
+  },
+  {
+    "name": "Filing",
+    "description": "Filing Event"
+  },
+  {
+    "name": "Granted",
+    "description": "Granted Event"
+  },
+  {
+    "name": "Implementation Details",
+    "description": "Implementation Details Event"
+  },
+  {
+    "name": "International Agreement",
+    "description": "International Agreement Event"
+  },
+  {
+    "name": "Net Zero Pledge",
+    "description": "Net Zero Pledge Event"
+  },
+  {
+    "name": "Other",
+    "description": "Other Event"
+  },
+  {
+    "name": "Passed/Approved",
+    "description": "Passed/Approved Event"
+  },
+  {
+    "name": "Repealed/Replaced",
+    "description": "Repealed/Replaced Event"
+  },
+  {
+    "name": "Set",
+    "description": "Set Event"
+  },
+  {
+    "name": "Settled",
+    "description": "Settled Event"
+  },
+  {
+    "name": "Updated",
+    "description": "Updated Event"
+  }
+]

--- a/db_client/alembic/versions/data/0047/new_document_type_data.json
+++ b/db_client/alembic/versions/data/0047/new_document_type_data.json
@@ -199,9 +199,6 @@
     "name": "Report"
   },
   {
-    "name": "Statement"
-  },
-  {
     "name": "Submission to the Global Stocktake"
   },
   {

--- a/db_client/alembic/versions/data/0047/new_document_type_data.json
+++ b/db_client/alembic/versions/data/0047/new_document_type_data.json
@@ -1,0 +1,273 @@
+[
+  {
+    "name": "Accord",
+    "description": "Accord"
+  },
+  {
+    "name": "Act",
+    "description": "Act"
+  },
+  {
+    "name": "Action Plan",
+    "description": "Action Plan"
+  },
+  {
+    "name": "Agenda",
+    "description": "Agenda"
+  },
+  {
+    "name": "Annex",
+    "description": "Annex"
+  },
+  {
+    "name": "Assessment",
+    "description": "Assessment"
+  },
+  {
+    "name": "Bill",
+    "description": "Bill"
+  },
+  {
+    "name": "Constitution",
+    "description": "Constitution"
+  },
+  {
+    "name": "Criteria",
+    "description": "Criteria"
+  },
+  {
+    "name": "Decision",
+    "description": "Decision"
+  },
+  {
+    "name": "Decision and Plan",
+    "description": "Decision and Plan"
+  },
+  {
+    "name": "Decree",
+    "description": "Decree"
+  },
+  {
+    "name": "Decree Law",
+    "description": "Decree Law"
+  },
+  {
+    "name": "Directive",
+    "description": "Directive"
+  },
+  {
+    "name": "Discussion Paper",
+    "description": "Discussion Paper"
+  },
+  {
+    "name": "Edict",
+    "description": "Edict"
+  },
+  {
+    "name": "EU Decision",
+    "description": "EU Decision"
+  },
+  {
+    "name": "EU Directive",
+    "description": "EU Directive"
+  },
+  {
+    "name": "EU Regulation",
+    "description": "EU Regulation"
+  },
+  {
+    "name": "Executive Order",
+    "description": "Executive Order"
+  },
+  {
+    "name": "Framework",
+    "description": "Framework"
+  },
+  {
+    "name": "Law",
+    "description": "Law"
+  },
+  {
+    "name": "Law and Plan",
+    "description": "Law and Plan"
+  },
+  {
+    "name": "Order",
+    "description": "Order"
+  },
+  {
+    "name": "Ordinance",
+    "description": "Ordinance"
+  },
+  {
+    "name": "Plan",
+    "description": "Plan"
+  },
+  {
+    "name": "Policy",
+    "description": "Policy"
+  },
+  {
+    "name": "Press Release",
+    "description": "Press Release"
+  },
+  {
+    "name": "Programme",
+    "description": "Programme"
+  },
+  {
+    "name": "Protocol",
+    "description": "Protocol"
+  },
+  {
+    "name": "Roadmap",
+    "description": "Roadmap"
+  },
+  {
+    "name": "Regulation",
+    "description": "Regulation"
+  },
+  {
+    "name": "Resolution",
+    "description": "Resolution"
+  },
+  {
+    "name": "Royal Decree",
+    "description": "Royal Decree"
+  },
+  {
+    "name": "Rules",
+    "description": "Rules"
+  },
+  {
+    "name": "Statement",
+    "description": "Statement"
+  },
+  {
+    "name": "Strategic Assessment",
+    "description": "Strategic Assessment"
+  },
+  {
+    "name": "Strategy",
+    "description": "Strategy"
+  },
+  {
+    "name": "Summary",
+    "description": "Summary"
+  },
+  {
+    "name": "Vision",
+    "description": "Vision"
+  },
+  {
+    "name": "Biennial Report"
+  },
+  {
+    "name": "Biennial Update Report"
+  },
+  {
+    "name": "Facilitative Sharing of Views Report"
+  },
+  {
+    "name": "Global Stocktake Synthesis Report"
+  },
+  {
+    "name": "Industry Report"
+  },
+  {
+    "name": "Intersessional Document"
+  },
+  {
+    "name": "Long-Term Low-Emission Development Strategy"
+  },
+  {
+    "name": "National Communication"
+  },
+  {
+    "name": "National Inventory Report"
+  },
+  {
+    "name": "Pre-Session Document"
+  },
+  {
+    "name": "Progress Report"
+  },
+  {
+    "name": "Publication"
+  },
+  {
+    "name": "Report"
+  },
+  {
+    "name": "Statement"
+  },
+  {
+    "name": "Submission to the Global Stocktake"
+  },
+  {
+    "name": "Summary Report"
+  },
+  {
+    "name": "Synthesis Report"
+  },
+  {
+    "name": "Technical Analysis Summary Report"
+  },
+  {
+    "name": "Nationally Determined Contribution"
+  },
+  {
+    "name": "Adaptation Communication"
+  },
+  {
+    "name": "National Adaptation Plan"
+  },
+  {
+    "name": "Technology Needs Assessment"
+  },
+  {
+    "name": "Fast-Start Finance Report"
+  },
+  {
+    "name": "IPCC Report"
+  },
+  {
+    "name": "Annual Compilation and Accounting Report"
+  },
+  {
+    "name": "Biennial Report,National Communication"
+  },
+  {
+    "name": "Biennial Update Report,National Communication"
+  },
+  {
+    "name": "National Adaptation Plan,Adaptation Communication"
+  },
+  {
+    "name": "National Communication,Biennial Report"
+  },
+  {
+    "name": "National Communication,Biennial Update Report"
+  },
+  {
+    "name": "Nationally Determined Contribution,Adaptation Communication"
+  },
+  {
+    "name": "Nationally Determined Contribution,National Communication"
+  },
+  {
+    "name": "Pre-Session Document,Annual Compilation and Accounting Report"
+  },
+  {
+    "name": "Pre-Session Document,Progress Report"
+  },
+  {
+    "name": "Pre-Session Document,Synthesis Report"
+  },
+  {
+    "name": "Publication,Report"
+  },
+  {
+    "name": "Technical Analysis Technical Report"
+  }
+]

--- a/db_client/alembic/versions/data/0048/document_role_data.json
+++ b/db_client/alembic/versions/data/0048/document_role_data.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "MAIN",
+    "description": "MAIN"
+  },
+  {
+    "name": "AMENDMENT",
+    "description": "AMENDMENT"
+  },
+  {
+    "name": "SUPPORTING LEGISLATION",
+    "description": "SUPPORTING LEGISLATION"
+  },
+  {
+    "name": "SUMMARY",
+    "description": "SUMMARY"
+  },
+  {
+    "name": "PREVIOUS VERSION",
+    "description": "PREVIOUS VERSION"
+  },
+  {
+    "name": "ANNEX",
+    "description": "ANNEX"
+  },
+  {
+    "name": "SUPPORTING DOCUMENTATION",
+    "description": "SUPPORTING DOCUMENTATION"
+  },
+  {
+    "name": "INFORMATION WEBPAGE",
+    "description": "INFORMATION WEBPAGE"
+  },
+  {
+    "name": "PRESS RELEASE",
+    "description": "PRESS RELEASE"
+  },
+  {
+    "name": "DOCUMENT(S) STORED ON WEBPAGE",
+    "description": "DOCUMENT(S) STORED ON WEBPAGE"
+  }
+]

--- a/db_client/alembic/versions/data/0048/event_type_data.json
+++ b/db_client/alembic/versions/data/0048/event_type_data.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "Amended",
+    "description": "Amended Event"
+  },
+  {
+    "name": "Appealed",
+    "description": "Appealed Event"
+  },
+  {
+    "name": "Closed",
+    "description": "Closed Event"
+  },
+  {
+    "name": "Declaration Of Climate Emergency",
+    "description": "Declaration Of Climate Emergency Event"
+  },
+  {
+    "name": "Dismissed",
+    "description": "Dismissed Event"
+  },
+  {
+    "name": "Entered Into Force",
+    "description": "Entered Into Force Event"
+  },
+  {
+    "name": "Filing",
+    "description": "Filing Event"
+  },
+  {
+    "name": "Granted",
+    "description": "Granted Event"
+  },
+  {
+    "name": "Implementation Details",
+    "description": "Implementation Details Event"
+  },
+  {
+    "name": "International Agreement",
+    "description": "International Agreement Event"
+  },
+  {
+    "name": "Net Zero Pledge",
+    "description": "Net Zero Pledge Event"
+  },
+  {
+    "name": "Other",
+    "description": "Other Event"
+  },
+  {
+    "name": "Passed/Approved",
+    "description": "Passed/Approved Event"
+  },
+  {
+    "name": "Repealed/Replaced",
+    "description": "Repealed/Replaced Event"
+  },
+  {
+    "name": "Set",
+    "description": "Set Event"
+  },
+  {
+    "name": "Settled",
+    "description": "Settled Event"
+  },
+  {
+    "name": "Updated",
+    "description": "Updated Event"
+  }
+]

--- a/db_client/alembic/versions/data/0048/framework_data.json
+++ b/db_client/alembic/versions/data/0048/framework_data.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Adaptation",
+    "description": "Adaptation"
+  },
+  {
+    "name": "Mitigation",
+    "description": "Mitigation"
+  },
+  {
+    "name": "Drm/Drr",
+    "description": "Drm/Drr"
+  }
+]

--- a/db_client/alembic/versions/data/0048/hazard_data.json
+++ b/db_client/alembic/versions/data/0048/hazard_data.json
@@ -1,0 +1,326 @@
+[
+  {
+    "name": "Flood",
+    "description": "Flood"
+  },
+  {
+    "name": "Drought",
+    "description": "Drought"
+  },
+  {
+    "name": "Storm",
+    "description": "Storm"
+  },
+  {
+    "name": "Erosion",
+    "description": "Erosion"
+  },
+  {
+    "name": "Floods",
+    "description": "Floods"
+  },
+  {
+    "name": "Droughts",
+    "description": "Droughts"
+  },
+  {
+    "name": "Cyclones",
+    "description": "Cyclones"
+  },
+  {
+    "name": "Tsunamis",
+    "description": "Tsunamis"
+  },
+  {
+    "name": "Storms",
+    "description": "Storms"
+  },
+  {
+    "name": "Hurricanes",
+    "description": "Hurricanes"
+  },
+  {
+    "name": "Changes In Air Quality",
+    "description": "Changes In Air Quality"
+  },
+  {
+    "name": "Heat Waves And Heat Stress",
+    "description": "Heat Waves And Heat Stress"
+  },
+  {
+    "name": "Soil Erosion",
+    "description": "Soil Erosion"
+  },
+  {
+    "name": "Changes In Average Precipitation",
+    "description": "Changes In Average Precipitation"
+  },
+  {
+    "name": "Sea Level Change",
+    "description": "Sea Level Change"
+  },
+  {
+    "name": "Change In Air Quality",
+    "description": "Change In Air Quality"
+  },
+  {
+    "name": "Heat Waves",
+    "description": "Heat Waves"
+  },
+  {
+    "name": "Change In Surface Water",
+    "description": "Change In Surface Water"
+  },
+  {
+    "name": "Surface Water Change",
+    "description": "Surface Water Change"
+  },
+  {
+    "name": "Changes In Average Temperature",
+    "description": "Changes In Average Temperature"
+  },
+  {
+    "name": "Groundwater Change",
+    "description": "Groundwater Change"
+  },
+  {
+    "name": "Earthquake",
+    "description": "Earthquake"
+  },
+  {
+    "name": "Glacial Melt",
+    "description": "Glacial Melt"
+  },
+  {
+    "name": "Wildfire",
+    "description": "Wildfire"
+  },
+  {
+    "name": "Earthquakes",
+    "description": "Earthquakes"
+  },
+  {
+    "name": "Mudslides",
+    "description": "Mudslides"
+  },
+  {
+    "name": "Wildfires",
+    "description": "Wildfires"
+  },
+  {
+    "name": "Changes In Soil Quality",
+    "description": "Changes In Soil Quality"
+  },
+  {
+    "name": "Changes In Surface Water",
+    "description": "Changes In Surface Water"
+  },
+  {
+    "name": "Glacial Melting",
+    "description": "Glacial Melting"
+  },
+  {
+    "name": "Snow Melt",
+    "description": "Snow Melt"
+  },
+  {
+    "name": "Change In Soil Quality",
+    "description": "Change In Soil Quality"
+  },
+  {
+    "name": "Storms, Hurricanes, Tsunamis, Cyclones",
+    "description": "Storms, Hurricanes, Tsunamis, Cyclones"
+  },
+  {
+    "name": "Ocean Acidification",
+    "description": "Ocean Acidification"
+  },
+  {
+    "name": "Sea Level Rise",
+    "description": "Sea Level Rise"
+  },
+  {
+    "name": "Landslides",
+    "description": "Landslides"
+  },
+  {
+    "name": "Heat Stress",
+    "description": "Heat Stress"
+  },
+  {
+    "name": "Glacial",
+    "description": "Glacial"
+  },
+  {
+    "name": "Heatwaves",
+    "description": "Heatwaves"
+  },
+  {
+    "name": "Changes In Precipitation",
+    "description": "Changes In Precipitation"
+  },
+  {
+    "name": "Change In Average Temperature",
+    "description": "Change In Average Temperature"
+  },
+  {
+    "name": "Fires",
+    "description": "Fires"
+  },
+  {
+    "name": "Desertification",
+    "description": "Desertification"
+  },
+  {
+    "name": "Cold Waves",
+    "description": "Cold Waves"
+  },
+  {
+    "name": "Loss Of Sea Ice",
+    "description": "Loss Of Sea Ice"
+  },
+  {
+    "name": "Avalanches",
+    "description": "Avalanches"
+  },
+  {
+    "name": "Changes In Groundwater",
+    "description": "Changes In Groundwater"
+  },
+  {
+    "name": "Loss Of Ice Mass",
+    "description": "Loss Of Ice Mass"
+  },
+  {
+    "name": "Earhquakes",
+    "description": "Earhquakes"
+  },
+  {
+    "name": "Biodiversity Loss",
+    "description": "Biodiversity Loss"
+  },
+  {
+    "name": "Windstorms",
+    "description": "Windstorms"
+  },
+  {
+    "name": "Forest Wildfires",
+    "description": "Forest Wildfires"
+  },
+  {
+    "name": "Coastal Erosion",
+    "description": "Coastal Erosion"
+  },
+  {
+    "name": "Lightning",
+    "description": "Lightning"
+  },
+  {
+    "name": "Windstorm",
+    "description": "Windstorm"
+  },
+  {
+    "name": "Heat Wave",
+    "description": "Heat Wave"
+  },
+  {
+    "name": "Cold Wave",
+    "description": "Cold Wave"
+  },
+  {
+    "name": "Wild Fire",
+    "description": "Wild Fire"
+  },
+  {
+    "name": "Fire",
+    "description": "Fire"
+  },
+  {
+    "name": "Epidemic",
+    "description": "Epidemic"
+  },
+  {
+    "name": "Landslide",
+    "description": "Landslide"
+  },
+  {
+    "name": "Land Erosion",
+    "description": "Land Erosion"
+  },
+  {
+    "name": "Hail",
+    "description": "Hail"
+  },
+  {
+    "name": "Flooding",
+    "description": "Flooding"
+  },
+  {
+    "name": "Hail/Frost",
+    "description": "Hail/Frost"
+  },
+  {
+    "name": "Loss Of Snow Cover",
+    "description": "Loss Of Snow Cover"
+  },
+  {
+    "name": "Hurricane",
+    "description": "Hurricane"
+  },
+  {
+    "name": "Tropical Cyclones",
+    "description": "Tropical Cyclones"
+  },
+  {
+    "name": "High Tides",
+    "description": "High Tides"
+  },
+  {
+    "name": "Diseases",
+    "description": "Diseases"
+  },
+  {
+    "name": "Volcano Eruptions",
+    "description": "Volcano Eruptions"
+  },
+  {
+    "name": "Heat",
+    "description": "Heat"
+  },
+  {
+    "name": "Sea Level Rise Soil Erosion",
+    "description": "Sea Level Rise Soil Erosion"
+  },
+  {
+    "name": "Sea Water Intrusion",
+    "description": "Sea Water Intrusion"
+  },
+  {
+    "name": "Forest",
+    "description": "Forest"
+  },
+  {
+    "name": "Typhoons",
+    "description": "Typhoons"
+  },
+  {
+    "name": "Melting Glacial Ice",
+    "description": "Melting Glacial Ice"
+  },
+  {
+    "name": "Soil Soil Erosion",
+    "description": "Soil Soil Erosion"
+  },
+  {
+    "name": "Thawing Permafrost",
+    "description": "Thawing Permafrost"
+  },
+  {
+    "name": "Increases In Heat Waves",
+    "description": "Increases In Heat Waves"
+  },
+  {
+    "name": "Permafrost Thawing",
+    "description": "Permafrost Thawing"
+  }
+]

--- a/db_client/alembic/versions/data/0048/instrument_data.json
+++ b/db_client/alembic/versions/data/0048/instrument_data.json
@@ -1,0 +1,202 @@
+[
+  {
+    "node": {
+      "name": "Processes, plans and strategies|Governance",
+      "description": "Processes, plans and strategies|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Subsidies|Economic",
+      "description": "Subsidies|Economic",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "International cooperation|Governance",
+      "description": "International cooperation|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Education, training and knowledge dissemination|Information",
+      "description": "Education, training and knowledge dissemination|Information",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Research & Development, knowledge generation|Information",
+      "description": "Research & Development, knowledge generation|Information",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Standards, obligations and norms|Regulation",
+      "description": "Standards, obligations and norms|Regulation",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Capacity building|Governance",
+      "description": "Capacity building|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Institutional mandates|Governance",
+      "description": "Institutional mandates|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "MRV|Governance",
+      "description": "MRV|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Tax incentives|Economic",
+      "description": "Tax incentives|Economic",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Provision of climate funds|Direct Investment",
+      "description": "Provision of climate funds|Direct Investment",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Other|Direct Investment",
+      "description": "Other|Direct Investment",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Early warning systems|Direct Investment",
+      "description": "Early warning systems|Direct Investment",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Subnational and citizen participation|Governance",
+      "description": "Subnational and citizen participation|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Insurance|Economic",
+      "description": "Insurance|Economic",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Climate finance tools|Economic",
+      "description": "Climate finance tools|Economic",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Zoning & Spatial Planning|Regulation",
+      "description": "Zoning & Spatial Planning|Regulation",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Nature based solutions and ecosystem restoration|Direct Investment",
+      "description": "Nature based solutions and ecosystem restoration|Direct Investment",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Disclosure obligations|Regulation",
+      "description": "Disclosure obligations|Regulation",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Other|Governance",
+      "description": "Other|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Planning|Governance",
+      "description": "Planning|Governance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Green procurement|Direct Investment",
+      "description": "Green procurement|Direct Investment",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Moratoria & bans|Regulation",
+      "description": "Moratoria & bans|Regulation",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Carbon pricing & emissions trading|Economic",
+      "description": "Carbon pricing & emissions trading|Economic",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Other|Economic",
+      "description": "Other|Economic",
+      "source": "CCLW"
+    },
+    "children": []
+  }
+]

--- a/db_client/alembic/versions/data/0048/keyword_data.json
+++ b/db_client/alembic/versions/data/0048/keyword_data.json
@@ -1,0 +1,878 @@
+[
+  {
+    "name": "Energy Supply",
+    "description": "Energy Supply"
+  },
+  {
+    "name": "Adaptation",
+    "description": "Adaptation"
+  },
+  {
+    "name": "Energy Demand",
+    "description": "Energy Demand"
+  },
+  {
+    "name": "Research And Development",
+    "description": "Research And Development"
+  },
+  {
+    "name": "Institutions / Administrative Arrangements",
+    "description": "Institutions / Administrative Arrangements"
+  },
+  {
+    "name": "Carbon Pricing",
+    "description": "Carbon Pricing"
+  },
+  {
+    "name": "Biofuels",
+    "description": "Biofuels"
+  },
+  {
+    "name": "Hydrogen",
+    "description": "Hydrogen"
+  },
+  {
+    "name": "Debt For Nature",
+    "description": "Debt For Nature"
+  },
+  {
+    "name": "Renewables",
+    "description": "Renewables"
+  },
+  {
+    "name": "Trees",
+    "description": "Trees"
+  },
+  {
+    "name": "Reforestation",
+    "description": "Reforestation"
+  },
+  {
+    "name": "Spatial Planning",
+    "description": "Spatial Planning"
+  },
+  {
+    "name": "Mangroves",
+    "description": "Mangroves"
+  },
+  {
+    "name": "Forests",
+    "description": "Forests"
+  },
+  {
+    "name": "Afforestation",
+    "description": "Afforestation"
+  },
+  {
+    "name": "Finance",
+    "description": "Finance"
+  },
+  {
+    "name": "Carbon Budget",
+    "description": "Carbon Budget"
+  },
+  {
+    "name": "Agriculture",
+    "description": "Agriculture"
+  },
+  {
+    "name": "Carbon Sink",
+    "description": "Carbon Sink"
+  },
+  {
+    "name": "Wetlands",
+    "description": "Wetlands"
+  },
+  {
+    "name": "Gender",
+    "description": "Gender"
+  },
+  {
+    "name": "Health",
+    "description": "Health"
+  },
+  {
+    "name": "Planning",
+    "description": "Planning"
+  },
+  {
+    "name": "Public Transport",
+    "description": "Public Transport"
+  },
+  {
+    "name": "Freight",
+    "description": "Freight"
+  },
+  {
+    "name": "Modal Shift",
+    "description": "Modal Shift"
+  },
+  {
+    "name": "Active Travel",
+    "description": "Active Travel"
+  },
+  {
+    "name": "Net Zero",
+    "description": "Net Zero"
+  },
+  {
+    "name": "Youth",
+    "description": "Youth"
+  },
+  {
+    "name": "Disaster Risk Management",
+    "description": "Disaster Risk Management"
+  },
+  {
+    "name": "Mitigation",
+    "description": "Mitigation"
+  },
+  {
+    "name": "Stimulus Plan",
+    "description": "Stimulus Plan"
+  },
+  {
+    "name": "Electricity",
+    "description": "Electricity"
+  },
+  {
+    "name": "Energy Efficiency",
+    "description": "Energy Efficiency"
+  },
+  {
+    "name": "Buildings",
+    "description": "Buildings"
+  },
+  {
+    "name": "Disease Prevention",
+    "description": "Disease Prevention"
+  },
+  {
+    "name": "Biodiversity",
+    "description": "Biodiversity"
+  },
+  {
+    "name": "Aviation",
+    "description": "Aviation"
+  },
+  {
+    "name": "Transport",
+    "description": "Transport"
+  },
+  {
+    "name": "Shipping",
+    "description": "Shipping"
+  },
+  {
+    "name": "Industry",
+    "description": "Industry"
+  },
+  {
+    "name": "Biogas",
+    "description": "Biogas"
+  },
+  {
+    "name": "Energy",
+    "description": "Energy"
+  },
+  {
+    "name": "Waste",
+    "description": "Waste"
+  },
+  {
+    "name": "Water Management",
+    "description": "Water Management"
+  },
+  {
+    "name": "Tax Incentives",
+    "description": "Tax Incentives"
+  },
+  {
+    "name": "Heat",
+    "description": "Heat"
+  },
+  {
+    "name": "Climate Change",
+    "description": "Climate Change"
+  },
+  {
+    "name": "Germany",
+    "description": "Germany"
+  },
+  {
+    "name": "Citizens' Assembly",
+    "description": "Citizens' Assembly"
+  },
+  {
+    "name": "Deforestation",
+    "description": "Deforestation"
+  },
+  {
+    "name": "Subsidies",
+    "description": "Subsidies"
+  },
+  {
+    "name": "Tax",
+    "description": "Tax"
+  },
+  {
+    "name": "Cycling",
+    "description": "Cycling"
+  },
+  {
+    "name": "Walking",
+    "description": "Walking"
+  },
+  {
+    "name": "Climate Fund",
+    "description": "Climate Fund"
+  },
+  {
+    "name": "National Energy And Climate Plans",
+    "description": "National Energy And Climate Plans"
+  },
+  {
+    "name": "Infrastructure",
+    "description": "Infrastructure"
+  },
+  {
+    "name": "Car Manufacturing",
+    "description": "Car Manufacturing"
+  },
+  {
+    "name": "Gas",
+    "description": "Gas"
+  },
+  {
+    "name": "Nuclear",
+    "description": "Nuclear"
+  },
+  {
+    "name": "Green Bonds",
+    "description": "Green Bonds"
+  },
+  {
+    "name": "Maritime Planning",
+    "description": "Maritime Planning"
+  },
+  {
+    "name": "Land Use",
+    "description": "Land Use"
+  },
+  {
+    "name": "Insurance",
+    "description": "Insurance"
+  },
+  {
+    "name": "Reinsurance",
+    "description": "Reinsurance"
+  },
+  {
+    "name": "Public Private",
+    "description": "Public Private"
+  },
+  {
+    "name": "Just Transition",
+    "description": "Just Transition"
+  },
+  {
+    "name": "Hydro",
+    "description": "Hydro"
+  },
+  {
+    "name": "Food Waste",
+    "description": "Food Waste"
+  },
+  {
+    "name": "Mountain",
+    "description": "Mountain"
+  },
+  {
+    "name": "Offshore",
+    "description": "Offshore"
+  },
+  {
+    "name": "Paris Agreement",
+    "description": "Paris Agreement"
+  },
+  {
+    "name": "Joe Biden",
+    "description": "Joe Biden"
+  },
+  {
+    "name": "Jobs",
+    "description": "Jobs"
+  },
+  {
+    "name": "National Security",
+    "description": "National Security"
+  },
+  {
+    "name": "Fossil Fuels Subsidies",
+    "description": "Fossil Fuels Subsidies"
+  },
+  {
+    "name": "Moratorium",
+    "description": "Moratorium"
+  },
+  {
+    "name": "Fossil Fuels Curbing Measures",
+    "description": "Fossil Fuels Curbing Measures"
+  },
+  {
+    "name": "Disclosure",
+    "description": "Disclosure"
+  },
+  {
+    "name": "Climate Neutrality",
+    "description": "Climate Neutrality"
+  },
+  {
+    "name": "Ban",
+    "description": "Ban"
+  },
+  {
+    "name": "Limits On Fossil Fuels",
+    "description": "Limits On Fossil Fuels"
+  },
+  {
+    "name": "Coal Phase Out",
+    "description": "Coal Phase Out"
+  },
+  {
+    "name": "Meat",
+    "description": "Meat"
+  },
+  {
+    "name": "Banking",
+    "description": "Banking"
+  },
+  {
+    "name": "Central Bank",
+    "description": "Central Bank"
+  },
+  {
+    "name": "Food Security",
+    "description": "Food Security"
+  },
+  {
+    "name": "Air Pollution",
+    "description": "Air Pollution"
+  },
+  {
+    "name": "Fuels",
+    "description": "Fuels"
+  },
+  {
+    "name": "Road",
+    "description": "Road"
+  },
+  {
+    "name": "Oil",
+    "description": "Oil"
+  },
+  {
+    "name": "Methane",
+    "description": "Methane"
+  },
+  {
+    "name": "Permit",
+    "description": "Permit"
+  },
+  {
+    "name": "Coastal Erosion",
+    "description": "Coastal Erosion"
+  },
+  {
+    "name": "Biomass",
+    "description": "Biomass"
+  },
+  {
+    "name": "Truck",
+    "description": "Truck"
+  },
+  {
+    "name": "Oceans",
+    "description": "Oceans"
+  },
+  {
+    "name": "Technology",
+    "description": "Technology"
+  },
+  {
+    "name": "Mining",
+    "description": "Mining"
+  },
+  {
+    "name": "Space",
+    "description": "Space"
+  },
+  {
+    "name": "Education",
+    "description": "Education"
+  },
+  {
+    "name": "Fisheries",
+    "description": "Fisheries"
+  },
+  {
+    "name": "Culture",
+    "description": "Culture"
+  },
+  {
+    "name": "Livestock",
+    "description": "Livestock"
+  },
+  {
+    "name": "Carbon Accounting",
+    "description": "Carbon Accounting"
+  },
+  {
+    "name": "Circular Economy",
+    "description": "Circular Economy"
+  },
+  {
+    "name": "Carbon Credits",
+    "description": "Carbon Credits"
+  },
+  {
+    "name": "Development",
+    "description": "Development"
+  },
+  {
+    "name": "Ozone",
+    "description": "Ozone"
+  },
+  {
+    "name": "Flaring",
+    "description": "Flaring"
+  },
+  {
+    "name": "Intergenerational",
+    "description": "Intergenerational"
+  },
+  {
+    "name": "Digital Transition",
+    "description": "Digital Transition"
+  },
+  {
+    "name": "Advertising",
+    "description": "Advertising"
+  },
+  {
+    "name": "Electromobility",
+    "description": "Electromobility"
+  },
+  {
+    "name": "Migration",
+    "description": "Migration"
+  },
+  {
+    "name": "Climate Finance",
+    "description": "Climate Finance"
+  },
+  {
+    "name": "Coal Mining",
+    "description": "Coal Mining"
+  },
+  {
+    "name": "Social Justice",
+    "description": "Social Justice"
+  },
+  {
+    "name": "Water",
+    "description": "Water"
+  },
+  {
+    "name": "Investment",
+    "description": "Investment"
+  },
+  {
+    "name": "Natural Resources",
+    "description": "Natural Resources"
+  },
+  {
+    "name": "Environmental Degradation",
+    "description": "Environmental Degradation"
+  },
+  {
+    "name": "Equity",
+    "description": "Equity"
+  },
+  {
+    "name": "Rivers",
+    "description": "Rivers"
+  },
+  {
+    "name": "No Adequate Category",
+    "description": "No Adequate Category"
+  },
+  {
+    "name": "Peat",
+    "description": "Peat"
+  },
+  {
+    "name": "Coal",
+    "description": "Coal"
+  },
+  {
+    "name": "Fossil Fuels",
+    "description": "Fossil Fuels"
+  },
+  {
+    "name": "Green New Deal",
+    "description": "Green New Deal"
+  },
+  {
+    "name": "Governance",
+    "description": "Governance"
+  },
+  {
+    "name": "Climate Change Risks",
+    "description": "Climate Change Risks"
+  },
+  {
+    "name": "Glaciers",
+    "description": "Glaciers"
+  },
+  {
+    "name": "Greenwashing",
+    "description": "Greenwashing"
+  },
+  {
+    "name": "Desertification",
+    "description": "Desertification"
+  },
+  {
+    "name": "Solar Panels",
+    "description": "Solar Panels"
+  },
+  {
+    "name": "Meteorology",
+    "description": "Meteorology"
+  },
+  {
+    "name": "Climate Justice",
+    "description": "Climate Justice"
+  },
+  {
+    "name": "Black Carbon",
+    "description": "Black Carbon"
+  },
+  {
+    "name": "Rail",
+    "description": "Rail"
+  },
+  {
+    "name": "Human Rights",
+    "description": "Human Rights"
+  },
+  {
+    "name": "Tourism",
+    "description": "Tourism"
+  },
+  {
+    "name": "Trading Scheme",
+    "description": "Trading Scheme"
+  },
+  {
+    "name": "Physical Activity",
+    "description": "Physical Activity"
+  },
+  {
+    "name": "Geothermal",
+    "description": "Geothermal"
+  },
+  {
+    "name": "Food",
+    "description": "Food"
+  },
+  {
+    "name": "Climate Emergency",
+    "description": "Climate Emergency"
+  },
+  {
+    "name": "TCFD",
+    "description": "TCFD"
+  },
+  {
+    "name": "Housing",
+    "description": "Housing"
+  },
+  {
+    "name": "Artificialisation",
+    "description": "Artificialisation"
+  },
+  {
+    "name": "Energy Conservation",
+    "description": "Energy Conservation"
+  },
+  {
+    "name": "Wind",
+    "description": "Wind"
+  },
+  {
+    "name": "Off Grid",
+    "description": "Off Grid"
+  },
+  {
+    "name": "Power Plant",
+    "description": "Power Plant"
+  },
+  {
+    "name": "Fossil Fuel Phase Out",
+    "description": "Fossil Fuel Phase Out"
+  },
+  {
+    "name": "Amazon Forest",
+    "description": "Amazon Forest"
+  },
+  {
+    "name": "European Green Deal",
+    "description": "European Green Deal"
+  },
+  {
+    "name": "Keystone",
+    "description": "Keystone"
+  },
+  {
+    "name": "Arctic",
+    "description": "Arctic"
+  },
+  {
+    "name": "Licensing",
+    "description": "Licensing"
+  },
+  {
+    "name": "Train",
+    "description": "Train"
+  },
+  {
+    "name": "Oil And Gas",
+    "description": "Oil And Gas"
+  },
+  {
+    "name": "Nuclear Fusion",
+    "description": "Nuclear Fusion"
+  },
+  {
+    "name": "Soil Erosion",
+    "description": "Soil Erosion"
+  },
+  {
+    "name": "Indigenous People",
+    "description": "Indigenous People"
+  },
+  {
+    "name": "Argentina",
+    "description": "Argentina"
+  },
+  {
+    "name": "Skills",
+    "description": "Skills"
+  },
+  {
+    "name": "Environmental Permit",
+    "description": "Environmental Permit"
+  },
+  {
+    "name": "Climate Protection",
+    "description": "Climate Protection"
+  },
+  {
+    "name": "Healthy Environment",
+    "description": "Healthy Environment"
+  },
+  {
+    "name": "Procurement",
+    "description": "Procurement"
+  },
+  {
+    "name": "Innovation",
+    "description": "Innovation"
+  },
+  {
+    "name": "Buses",
+    "description": "Buses"
+  },
+  {
+    "name": "Energy Storage",
+    "description": "Energy Storage"
+  },
+  {
+    "name": "Hydrofluorocarbons",
+    "description": "Hydrofluorocarbons"
+  },
+  {
+    "name": "Nitrous Oxide",
+    "description": "Nitrous Oxide"
+  },
+  {
+    "name": "Delta",
+    "description": "Delta"
+  },
+  {
+    "name": "Divestment",
+    "description": "Divestment"
+  },
+  {
+    "name": "Co-generation",
+    "description": "Co-generation"
+  },
+  {
+    "name": "BRT",
+    "description": "BRT"
+  },
+  {
+    "name": "E-Buses",
+    "description": "E-Buses"
+  },
+  {
+    "name": "CCS",
+    "description": "CCS"
+  },
+  {
+    "name": "Co-benefits",
+    "description": "Co-benefits"
+  },
+  {
+    "name": "DRR",
+    "description": "DRR"
+  },
+  {
+    "name": "LULUCF",
+    "description": "LULUCF"
+  },
+  {
+    "name": "PV",
+    "description": "PV"
+  },
+  {
+    "name": "SLCPs",
+    "description": "SLCPs"
+  },
+  {
+    "name": "Multi-Modal Transport",
+    "description": "Multi-Modal Transport"
+  },
+  {
+    "name": "ETS",
+    "description": "ETS"
+  },
+  {
+    "name": "REDD+ And LULUCF",
+    "description": "REDD+ And LULUCF"
+  },
+  {
+    "name": "Taxonomy",
+    "description": "Taxonomy"
+  },
+  {
+    "name": "SDGs",
+    "description": "SDGs"
+  },
+  {
+    "name": "COVID-19",
+    "description": "COVID-19"
+  },
+  {
+    "name": "Climate Security",
+    "description": "Climate Security"
+  },
+  {
+    "name": "GHG",
+    "description": "GHG"
+  },
+  {
+    "name": "CDM",
+    "description": "CDM"
+  },
+  {
+    "name": "EVs",
+    "description": "EVs"
+  },
+  {
+    "name": "Solar",
+    "description": "Solar"
+  },
+  {
+    "name": "MRV",
+    "description": "MRV"
+  },
+  {
+    "name": "Clothing",
+    "description": "Clothing"
+  },
+  {
+    "name": "NAP",
+    "description": "NAP"
+  },
+  {
+    "name": "CCGAP",
+    "description": "CCGAP"
+  },
+  {
+    "name": "UNFCCC",
+    "description": "UNFCCC"
+  },
+  {
+    "name": "Cap and Trade",
+    "description": "Cap and Trade"
+  },
+  {
+    "name": "Travel",
+    "description": "Travel"
+  },
+  {
+    "name": "FIT",
+    "description": "FIT"
+  },
+  {
+    "name": "5G",
+    "description": "5G"
+  },
+  {
+    "name": "Carbon Capture and Storage",
+    "description": "Carbon Capture and Storage"
+  },
+  {
+    "name": "K-ETS",
+    "description": "K-ETS"
+  },
+  {
+    "name": "CBDR",
+    "description": "CBDR"
+  },
+  {
+    "name": "Cities",
+    "description": "Cities"
+  },
+  {
+    "name": "Airport",
+    "description": "Airport"
+  },
+  {
+    "name": "Future Generations",
+    "description": "Future Generations"
+  },
+  {
+    "name": "Environmental Impact Assessment",
+    "description": "Environmental Impact Assessment"
+  },
+  {
+    "name": "Reporting",
+    "description": "Reporting"
+  },
+  {
+    "name": "Energy Transition",
+    "description": "Energy Transition"
+  },
+  {
+    "name": "Adaptation Planning",
+    "description": "Adaptation Planning"
+  },
+  {
+    "name": "HFCs",
+    "description": "HFCs"
+  }
+]

--- a/db_client/alembic/versions/data/0048/new_document_type_data.json
+++ b/db_client/alembic/versions/data/0048/new_document_type_data.json
@@ -1,0 +1,270 @@
+[
+  {
+    "name": "Accord",
+    "description": "Accord"
+  },
+  {
+    "name": "Act",
+    "description": "Act"
+  },
+  {
+    "name": "Action Plan",
+    "description": "Action Plan"
+  },
+  {
+    "name": "Agenda",
+    "description": "Agenda"
+  },
+  {
+    "name": "Annex",
+    "description": "Annex"
+  },
+  {
+    "name": "Assessment",
+    "description": "Assessment"
+  },
+  {
+    "name": "Bill",
+    "description": "Bill"
+  },
+  {
+    "name": "Constitution",
+    "description": "Constitution"
+  },
+  {
+    "name": "Criteria",
+    "description": "Criteria"
+  },
+  {
+    "name": "Decision",
+    "description": "Decision"
+  },
+  {
+    "name": "Decision and Plan",
+    "description": "Decision and Plan"
+  },
+  {
+    "name": "Decree",
+    "description": "Decree"
+  },
+  {
+    "name": "Decree Law",
+    "description": "Decree Law"
+  },
+  {
+    "name": "Directive",
+    "description": "Directive"
+  },
+  {
+    "name": "Discussion Paper",
+    "description": "Discussion Paper"
+  },
+  {
+    "name": "Edict",
+    "description": "Edict"
+  },
+  {
+    "name": "EU Decision",
+    "description": "EU Decision"
+  },
+  {
+    "name": "EU Directive",
+    "description": "EU Directive"
+  },
+  {
+    "name": "EU Regulation",
+    "description": "EU Regulation"
+  },
+  {
+    "name": "Executive Order",
+    "description": "Executive Order"
+  },
+  {
+    "name": "Framework",
+    "description": "Framework"
+  },
+  {
+    "name": "Law",
+    "description": "Law"
+  },
+  {
+    "name": "Law and Plan",
+    "description": "Law and Plan"
+  },
+  {
+    "name": "Order",
+    "description": "Order"
+  },
+  {
+    "name": "Ordinance",
+    "description": "Ordinance"
+  },
+  {
+    "name": "Plan",
+    "description": "Plan"
+  },
+  {
+    "name": "Policy",
+    "description": "Policy"
+  },
+  {
+    "name": "Press Release",
+    "description": "Press Release"
+  },
+  {
+    "name": "Programme",
+    "description": "Programme"
+  },
+  {
+    "name": "Protocol",
+    "description": "Protocol"
+  },
+  {
+    "name": "Roadmap",
+    "description": "Roadmap"
+  },
+  {
+    "name": "Regulation",
+    "description": "Regulation"
+  },
+  {
+    "name": "Resolution",
+    "description": "Resolution"
+  },
+  {
+    "name": "Royal Decree",
+    "description": "Royal Decree"
+  },
+  {
+    "name": "Rules",
+    "description": "Rules"
+  },
+  {
+    "name": "Statement",
+    "description": "Statement"
+  },
+  {
+    "name": "Strategic Assessment",
+    "description": "Strategic Assessment"
+  },
+  {
+    "name": "Strategy",
+    "description": "Strategy"
+  },
+  {
+    "name": "Summary",
+    "description": "Summary"
+  },
+  {
+    "name": "Vision",
+    "description": "Vision"
+  },
+  {
+    "name": "Biennial Report"
+  },
+  {
+    "name": "Biennial Update Report"
+  },
+  {
+    "name": "Facilitative Sharing of Views Report"
+  },
+  {
+    "name": "Global Stocktake Synthesis Report"
+  },
+  {
+    "name": "Industry Report"
+  },
+  {
+    "name": "Intersessional Document"
+  },
+  {
+    "name": "Long-Term Low-Emission Development Strategy"
+  },
+  {
+    "name": "National Communication"
+  },
+  {
+    "name": "National Inventory Report"
+  },
+  {
+    "name": "Pre-Session Document"
+  },
+  {
+    "name": "Progress Report"
+  },
+  {
+    "name": "Publication"
+  },
+  {
+    "name": "Report"
+  },
+  {
+    "name": "Submission to the Global Stocktake"
+  },
+  {
+    "name": "Summary Report"
+  },
+  {
+    "name": "Synthesis Report"
+  },
+  {
+    "name": "Technical Analysis Summary Report"
+  },
+  {
+    "name": "Nationally Determined Contribution"
+  },
+  {
+    "name": "Adaptation Communication"
+  },
+  {
+    "name": "National Adaptation Plan"
+  },
+  {
+    "name": "Technology Needs Assessment"
+  },
+  {
+    "name": "Fast-Start Finance Report"
+  },
+  {
+    "name": "IPCC Report"
+  },
+  {
+    "name": "Annual Compilation and Accounting Report"
+  },
+  {
+    "name": "Biennial Report,National Communication"
+  },
+  {
+    "name": "Biennial Update Report,National Communication"
+  },
+  {
+    "name": "National Adaptation Plan,Adaptation Communication"
+  },
+  {
+    "name": "National Communication,Biennial Report"
+  },
+  {
+    "name": "National Communication,Biennial Update Report"
+  },
+  {
+    "name": "Nationally Determined Contribution,Adaptation Communication"
+  },
+  {
+    "name": "Nationally Determined Contribution,National Communication"
+  },
+  {
+    "name": "Pre-Session Document,Annual Compilation and Accounting Report"
+  },
+  {
+    "name": "Pre-Session Document,Progress Report"
+  },
+  {
+    "name": "Pre-Session Document,Synthesis Report"
+  },
+  {
+    "name": "Publication,Report"
+  },
+  {
+    "name": "Technical Analysis Technical Report"
+  }
+]

--- a/db_client/alembic/versions/data/0048/sector_data.json
+++ b/db_client/alembic/versions/data/0048/sector_data.json
@@ -1,0 +1,194 @@
+[
+  {
+    "node": {
+      "name": "Energy",
+      "description": "Energy",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "LULUCF",
+      "description": "LULUCF",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Social development",
+      "description": "Social development",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Transportation",
+      "description": "Transportation",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Urban",
+      "description": "Urban",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Waste",
+      "description": "Waste",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Coastal zones",
+      "description": "Coastal zones",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Environment",
+      "description": "Environment",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Industry",
+      "description": "Industry",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Residential and Commercial",
+      "description": "Residential and Commercial",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Water",
+      "description": "Water",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Agriculture",
+      "description": "Agriculture",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Health",
+      "description": "Health",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Economy-wide",
+      "description": "Economy-wide",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Disaster Risk Management (Drm)",
+      "description": "Disaster Risk Management (Drm)",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Transport",
+      "description": "Transport",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Tourism",
+      "description": "Tourism",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Rural",
+      "description": "Rural",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Adaptation",
+      "description": "Adaptation",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Other",
+      "description": "Other",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Finance",
+      "description": "Finance",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Public Sector",
+      "description": "Public Sector",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Cross Cutting Area",
+      "description": "Cross Cutting Area",
+      "source": "CCLW"
+    },
+    "children": []
+  },
+  {
+    "node": {
+      "name": "Buildings",
+      "description": "Buildings",
+      "source": "CCLW"
+    },
+    "children": []
+  }
+]

--- a/db_client/alembic/versions/data/0048/topic_data.json
+++ b/db_client/alembic/versions/data/0048/topic_data.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Mitigation",
+    "description": "Mitigation"
+  },
+  {
+    "name": "Adaptation",
+    "description": "Adaptation"
+  },
+  {
+    "name": "Loss And Damage",
+    "description": "Loss And Damage"
+  },
+  {
+    "name": "Disaster Risk Management",
+    "description": "Disaster Risk Management"
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.6"
+version = "3.8.7"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/schema/test_inital_data.py
+++ b/tests/schema/test_inital_data.py
@@ -25,7 +25,7 @@ EXPECTED_CCLW_INSTRUMENTS = 25
 EXPECTED_UNFCCC_TAXONOMY = {"author", "author_type", "event_type", "_document"}
 EXPECTED_UNFCCC_AUTHOR_TYPES = 2
 
-EXPECTED_DOCUMENT_TAXONOMY_KEYS = 1
+EXPECTED_DOCUMENT_TAXONOMY_KEYS = 2
 
 EXPECTED_ORGANISATIONS = 2
 EXPECTED_EVENT_TYPES = 17
@@ -181,13 +181,25 @@ def test_taxonomy_value_counts_correct(
         (
             "UNFCCC",
             [
-                ("_document", [("role", EXPECTED_DOCUMENT_ROLE)]),
+                (
+                    "_document",
+                    [
+                        ("role", EXPECTED_DOCUMENT_ROLE),
+                        ("type", EXPECTED_DOCUMENT_TYPE),
+                    ],
+                ),
             ],
         ),
         (
             "CCLW",
             [
-                ("_document", [("role", EXPECTED_DOCUMENT_ROLE)]),
+                (
+                    "_document",
+                    [
+                        ("role", EXPECTED_DOCUMENT_ROLE),
+                        ("type", EXPECTED_DOCUMENT_TYPE),
+                    ],
+                ),
             ],
         ),
     ],


### PR DESCRIPTION
# What's changed

- Moved the document type into _document sub taxonomy
- Updated tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
