### PR TITLE
pdct 1246 copy document type into family doc metadata column object

### DIFF
--- a/db_client/alembic/versions/0049_copy_document_type_into_metadata.py
+++ b/db_client/alembic/versions/0049_copy_document_type_into_metadata.py
@@ -1,0 +1,30 @@
+"""Copy document type into metadata.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2024-07-17 14:01:33.721363
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0049"
+down_revision = "0048"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        sa.text(
+            "UPDATE family_document "
+            "SET valid_metadata = jsonb_set("
+            "valid_metadata, '{type}', to_jsonb(ARRAY[document_type]), true) "
+            "WHERE valid_metadata ? 'type' = false"
+        )
+    )
+
+
+def downgrade():
+    pass  # No way back

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.7"
+version = "3.8.8"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
