### PR TITLE
PDCT-1327 Add MCF as a new FamilyCategory

### DIFF
--- a/db_client/alembic/versions/0052_add_mcf_as_new_family_category.py
+++ b/db_client/alembic/versions/0052_add_mcf_as_new_family_category.py
@@ -16,8 +16,7 @@ depends_on = None
 
 
 def upgrade():
-    with op.get_context().autocommit_block():
-        op.execute("ALTER TYPE familycategory ADD VALUE 'MCF'")
+    op.execute("ALTER TYPE familycategory ADD VALUE 'MCF'")
 
 
 def downgrade():

--- a/db_client/alembic/versions/0052_add_mcf_as_new_family_category.py
+++ b/db_client/alembic/versions/0052_add_mcf_as_new_family_category.py
@@ -1,0 +1,24 @@
+"""add MCF as new family category
+
+Revision ID: 0052
+Revises: 0051
+Create Date: 2024-08-12 14:52:42.190073
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0052"
+down_revision = "0051"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE familycategory ADD VALUE 'MCF'")
+
+
+def downgrade():
+    pass

--- a/db_client/models/dfce/family.py
+++ b/db_client/models/dfce/family.py
@@ -19,6 +19,7 @@ class FamilyCategory(BaseModelEnum):
     EXECUTIVE = "Executive"
     LEGISLATIVE = "Legislative"
     UNFCCC = "UNFCCC"
+    MCF = "MCF"
 
 
 class Variant(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.10"
+version = "3.8.11"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

Simply adds "MCF" as a new FamilyCategory to the enum in PostgreSQL

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
