### PR TITLE
Fix add document helper function

### DIFF
--- a/db_client/functions/dfce_helpers.py
+++ b/db_client/functions/dfce_helpers.py
@@ -143,11 +143,11 @@ def add_document(db: Session, family_import_id, d):
             import_id=d["import_id"],
             variant_name=d["language_variant"],
             document_status=d["status"],
-            document_type=d["type"],
-            document_role=d["role"],
+            valid_metadata=d["metadata"],
         )
     )
     db.flush()
+
     for lang in d["languages"]:
         db_lang = db.query(Language).filter(Language.language_code == lang).one()
         db.add(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.16"
+version = "3.8.17"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

- Update add document helper function to add document metadata under metadata key rather than flattening the metadata at the root level

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
