### PR TITLE
feature/pdct-1371 Make metadata validator more robust

### DIFF
--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Mapping, Optional, Sequence, Union
 
 from sqlalchemy.orm import Session
@@ -14,6 +15,7 @@ from db_client.models.dfce.taxonomy_entry import (
 )
 
 MetadataValidationErrors = Sequence[str]
+_LOGGER = logging.getLogger(__name__)
 
 
 def validate_metadata(
@@ -72,6 +74,7 @@ def validate_metadata_against_taxonomy(
     try:
         taxonomy_entries = build_valid_taxonomy(taxonomy)
     except TypeError as e:
+        _LOGGER.error(e)
         # Wrap any TypeError in a more general error
         raise TypeError("Bad Taxonomy data in database") from e
 
@@ -144,6 +147,7 @@ def build_valid_taxonomy(taxonomy: Mapping) -> Mapping[str, TaxonomyEntry]:
     taxonomy_entries: Mapping[str, TaxonomyEntry] = {}
 
     for key, values in taxonomy.items():
+        # TODO: Remove the key not in part of this conditional as part of PDCT-1435.
         if key not in [
             "allow_any",
             "allow_blanks",

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -167,7 +167,9 @@ def build_valid_taxonomy(
 
     for key, values in taxonomy.items():
         if not isinstance(values, dict):
-            raise TypeError(f"Taxonomy entry for '{key}' is not a dictionary")
+            raise TypeError(
+                f"Taxonomy entry for '{key}' is not a dictionary: {taxonomy.keys()}"
+            )
 
         # We rely on pydantic to validate the values here
         taxonomy_entries[key] = TaxonomyEntry(**values)

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -153,11 +153,11 @@ def build_valid_taxonomy(
     # TODO: Remove as part of PDCT-1435.
     if (
         all(
-            k in list(taxonomy.keys())
-            for k in ["allow_any", "allow_blanks", "allowed_values"]
+            k in ["allow_any", "allow_blanks", "allowed_values"]
+            for k in list(taxonomy.keys())
         )
         and metadata is not None
-        and metadata.keys() == [EntitySpecificTaxonomyKeys.EVENT.value]
+        and list(metadata.keys()) == [EntitySpecificTaxonomyKeys.EVENT.value]
     ):
         taxonomy_entries[EntitySpecificTaxonomyKeys.EVENT.value] = TaxonomyEntry(
             **taxonomy
@@ -166,14 +166,7 @@ def build_valid_taxonomy(
 
     for key, values in taxonomy.items():
         if not isinstance(values, dict):
-            raise TypeError(
-                f"Taxonomy entry for '{key}' is not a dictionary: {taxonomy.keys()}, "
-                f"metadata {metadata}, "
-                f"{all(k in list(taxonomy.keys()) for k in ['allow_any', 'allow_blanks', 'allowed_values'])}"
-                f"{all(k in ['allow_any', 'allow_blanks', 'allowed_values'] for k in list(taxonomy.keys()))}"
-                f"{metadata.keys() == [EntitySpecificTaxonomyKeys.EVENT.value] if metadata is not None else None},"
-                f"{list(metadata.keys()) == [EntitySpecificTaxonomyKeys.EVENT.value] if metadata is not None else None}"
-            )
+            raise TypeError(f"Taxonomy entry for '{key}' is not a dictionary")
 
         # We rely on pydantic to validate the values here
         taxonomy_entries[key] = TaxonomyEntry(**values)

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -151,6 +151,7 @@ def build_valid_taxonomy(
     taxonomy_entries: Mapping[str, TaxonomyEntry] = {}
 
     # TODO: Remove as part of PDCT-1435.
+    _LOGGER.info(taxonomy.keys())
     if (
         all(
             k in ["allow_any", "allow_blanks", "allowed_values"]

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -142,9 +142,13 @@ def build_valid_taxonomy(taxonomy: Mapping) -> Mapping[str, TaxonomyEntry]:
         raise TypeError("Taxonomy is not a dictionary")
 
     taxonomy_entries: Mapping[str, TaxonomyEntry] = {}
-    for key, values in taxonomy.items():
 
-        if not isinstance(values, dict):
+    for key, values in taxonomy.items():
+        if key not in [
+            "allow_any",
+            "allow_blanks",
+            "allowed_values",
+        ] and not isinstance(values, dict):
             raise TypeError(f"Taxonomy entry for '{key}' is not a dictionary")
 
         # We rely on pydantic to validate the values here

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -171,6 +171,7 @@ def build_valid_taxonomy(
                 f"metadata {metadata}, "
                 f"{all(k in list(taxonomy.keys()) for k in ['allow_any', 'allow_blanks', 'allowed_values'])}"
                 f"{all(k in ['allow_any', 'allow_blanks', 'allowed_values'] for k in list(taxonomy.keys()))}"
+                f"{metadata.keys() == [EntitySpecificTaxonomyKeys.EVENT.value] if metadata is not None else None}"
             )
 
         # We rely on pydantic to validate the values here

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -168,7 +168,7 @@ def build_valid_taxonomy(
     for key, values in taxonomy.items():
         if not isinstance(values, dict):
             raise TypeError(
-                f"Taxonomy entry for '{key}' is not a dictionary: {taxonomy.keys()}"
+                f"Taxonomy entry for '{key}' is not a dictionary: {taxonomy.keys()}, metadata {metadata}"
             )
 
         # We rely on pydantic to validate the values here

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -151,10 +151,9 @@ def build_valid_taxonomy(
     taxonomy_entries: Mapping[str, TaxonomyEntry] = {}
 
     # TODO: Remove as part of PDCT-1435.
-    _LOGGER.info(taxonomy.keys())
     if (
         all(
-            k in taxonomy.keys()
+            k in list(taxonomy.keys())
             for k in ["allow_any", "allow_blanks", "allowed_values"]
         )
         and metadata is not None
@@ -168,7 +167,10 @@ def build_valid_taxonomy(
     for key, values in taxonomy.items():
         if not isinstance(values, dict):
             raise TypeError(
-                f"Taxonomy entry for '{key}' is not a dictionary: {taxonomy.keys()}, metadata {metadata}"
+                f"Taxonomy entry for '{key}' is not a dictionary: {taxonomy.keys()}, "
+                f"metadata {metadata}, "
+                f"{all(k in list(taxonomy.keys()) for k in ['allow_any', 'allow_blanks', 'allowed_values'])}"
+                f"{all(k in ['allow_any', 'allow_blanks', 'allowed_values'] for k in list(taxonomy.keys()))}"
             )
 
         # We rely on pydantic to validate the values here

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -171,7 +171,8 @@ def build_valid_taxonomy(
                 f"metadata {metadata}, "
                 f"{all(k in list(taxonomy.keys()) for k in ['allow_any', 'allow_blanks', 'allowed_values'])}"
                 f"{all(k in ['allow_any', 'allow_blanks', 'allowed_values'] for k in list(taxonomy.keys()))}"
-                f"{metadata.keys() == [EntitySpecificTaxonomyKeys.EVENT.value] if metadata is not None else None}"
+                f"{metadata.keys() == [EntitySpecificTaxonomyKeys.EVENT.value] if metadata is not None else None},"
+                f"{list(metadata.keys()) == [EntitySpecificTaxonomyKeys.EVENT.value] if metadata is not None else None}"
             )
 
         # We rely on pydantic to validate the values here

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -154,8 +154,8 @@ def build_valid_taxonomy(
     _LOGGER.info(taxonomy.keys())
     if (
         all(
-            k in ["allow_any", "allow_blanks", "allowed_values"]
-            for k in taxonomy.keys()
+            k in taxonomy.keys()
+            for k in ["allow_any", "allow_blanks", "allowed_values"]
         )
         and metadata is not None
         and metadata.keys() == [EntitySpecificTaxonomyKeys.EVENT.value]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.17"
+version = "3.8.18"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

- Make metadata builder more robust for event validation

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
