### PR TITLE
Feature/pdct 1440 Update DFCE helper to add multiple fam geos

### DIFF
--- a/db_client/functions/dfce_helpers.py
+++ b/db_client/functions/dfce_helpers.py
@@ -74,12 +74,18 @@ def add_families(db: Session, families, org_id=1):
         )
         db.add(new_slug)
 
-        db.add(
-            FamilyGeography(
-                family_import_id=f["import_id"],
-                geography_id=f["geography_id"],
-            )
+        geo_ids = (
+            f["geography_id"]
+            if isinstance(f["geography_id"], list)
+            else [f["geography_id"]]
         )
+        for geo_id in geo_ids:
+            db.add(
+                FamilyGeography(
+                    family_import_id=f["import_id"],
+                    geography_id=geo_id,
+                )
+            )
 
         for d in f["documents"]:
             add_document(db, f["import_id"], d)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.18"
+version = "3.8.19"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

Update DFCE helpers to add multiple family geographies.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
