### PR TITLE
Add some tests for collection & family dfce helpers

### DIFF
--- a/tests/functions/dfce_helpers/test_add_collections.py
+++ b/tests/functions/dfce_helpers/test_add_collections.py
@@ -1,0 +1,61 @@
+from db_client.functions.dfce_helpers import add_collections
+from db_client.models.dfce.collection import Collection, CollectionOrganisation
+
+
+def test_add_collections__one_collection(test_db):
+    collection1 = {
+        "import_id": "CPR.Collection.1.0",
+        "title": "Collection1",
+        "description": "CollectionSummary1",
+    }
+    add_collections(test_db, collections=[collection1])
+
+    collections = test_db.query(Collection).all()
+    assert len(collections) == 1
+
+    collection = collections[0]
+    assert collection.import_id == "CPR.Collection.1.0"
+    assert collection.title == "Collection1"
+    assert collection.description == "CollectionSummary1"
+
+
+def test_add_collections__multiple_collections(test_db):
+    collection1 = {
+        "import_id": "CPR.Collection.1.0",
+        "title": "Collection1",
+        "description": "CollectionSummary1",
+    }
+    collection2 = {
+        "import_id": "CPR.Collection.2.0",
+        "title": "Collection2",
+        "description": "CollectionSummary2",
+    }
+    add_collections(test_db, collections=[collection1, collection2])
+
+    collections = test_db.query(Collection).all()
+    assert len(test_db.query(Collection).all()) == 2
+
+    assert all(
+        [
+            collection.import_id in ["CPR.Collection.1.0", "CPR.Collection.2.0"]
+            for collection in collections
+        ]
+    )
+
+
+def test_add_collections__organisations(test_db):
+    collection1 = {
+        "import_id": "CPR.Collection.1.0",
+        "title": "Collection1",
+        "description": "CollectionSummary1",
+    }
+    add_collections(test_db, collections=[collection1])
+
+    assert len(test_db.query(Collection).all()) == 1
+
+    collections = test_db.query(CollectionOrganisation).all()
+    assert len(collections) == 1
+
+    collection = collections[0]
+    assert collection.collection_import_id == "CPR.Collection.1.0"
+    assert collection.organisation_id == 1

--- a/tests/functions/dfce_helpers/test_add_families.py
+++ b/tests/functions/dfce_helpers/test_add_families.py
@@ -1,9 +1,13 @@
+from typing import cast
+
 from db_client.functions.dfce_helpers import (
     add_collections,
     add_families,
     link_collection_family,
 )
 from db_client.models.dfce.collection import CollectionFamily
+from db_client.models.dfce.family import FamilyGeography
+from db_client.models.dfce.geography import Geography
 
 
 def test_add_families__link_collection_family(test_db):
@@ -40,3 +44,65 @@ def test_add_families__link_collection_family(test_db):
     collection_family_link = collection_family_links[0]  # type: ignore
     assert collection_family_link.collection_import_id == "CPR.Collection.1.0"
     assert collection_family_link.family_import_id == "CCLW.family.3003.0"
+
+
+def test_add_families__family_geos(test_db):
+    document = {
+        "title": "Document3",
+        "slug": "DocSlug3",
+        "md5_sum": None,
+        "url": "http://another_somewhere",
+        "content_type": None,
+        "import_id": "CCLW.executive.3.3",
+        "language_variant": None,
+        "status": "PUBLISHED",
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
+        "languages": [],
+        "events": [
+            {
+                "import_id": "CPR.Event.3.0",
+                "title": "Published",
+                "date": "2019-12-25",
+                "type": "Passed/Approved",
+                "status": "OK",
+            }
+        ],
+    }
+    family = {
+        "import_id": "CCLW.family.3003.0",
+        "corpus_import_id": "CCLW.corpus.i00000001.n0000",
+        "title": "Fam3",
+        "slug": "FamSlug3",
+        "description": "Summary3",
+        "geography_id": [2, 5],
+        "category": "UNFCCC",
+        "documents": [],
+        "metadata": {
+            "size": "small",
+            "color": "blue",
+        },
+    }
+    family["documents"] = [document]
+    add_families(test_db, families=[family])
+
+    family_geos = (
+        test_db.query(FamilyGeography)
+        .filter(FamilyGeography.family_import_id == "CCLW.family.3003.0")
+        .all()
+    )
+    assert len(family_geos) == 2
+
+    ind_id = (
+        test_db.query(Geography.id).filter(Geography.display_value == "India").scalar()
+    )
+    afg_id = (
+        test_db.query(Geography.id)
+        .filter(Geography.display_value == "Afghanistan")
+        .scalar()
+    )
+    assert all(
+        [
+            cast(int, family_geo.geography_id) in [ind_id, afg_id]
+            for family_geo in family_geos
+        ]
+    )

--- a/tests/functions/dfce_helpers/test_add_families.py
+++ b/tests/functions/dfce_helpers/test_add_families.py
@@ -1,0 +1,42 @@
+from db_client.functions.dfce_helpers import (
+    add_collections,
+    add_families,
+    link_collection_family,
+)
+from db_client.models.dfce.collection import CollectionFamily
+
+
+def test_add_families__link_collection_family(test_db):
+    family = {
+        "import_id": "CCLW.family.3003.0",
+        "corpus_import_id": "CCLW.corpus.i00000001.n0000",
+        "title": "Fam3",
+        "slug": "FamSlug3",
+        "description": "Summary3",
+        "geography_id": [2, 5],
+        "category": "UNFCCC",
+        "documents": [],
+        "metadata": {
+            "size": "small",
+            "color": "blue",
+        },
+    }
+    add_families(test_db, families=[family])
+
+    collection = {
+        "import_id": "CPR.Collection.1.0",
+        "title": "Collection1",
+        "description": "CollectionSummary1",
+    }
+    add_collections(test_db, collections=[collection])
+
+    link_collection_family(
+        test_db, [(str("CPR.Collection.1.0"), str("CCLW.family.3003.0"))]
+    )
+
+    collection_family_links = test_db.query(CollectionFamily).all()
+    assert len(collection_family_links) == 1
+
+    collection_family_link = collection_family_links[0]  # type: ignore
+    assert collection_family_link.collection_import_id == "CPR.Collection.1.0"
+    assert collection_family_link.family_import_id == "CCLW.family.3003.0"


### PR DESCRIPTION
# What's changed

I noticed we're missing coverage for the DFCE helpers in the db client. We do some verification in our tests after using these helpers, but I think if we had separate coverage of these in the db client it would help build confidence.

I haven't had time to make these comprehensive yet (hence only adding some collection & family test cases for now) due to prioritisation - hopefully we can get to this after COP.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
