### PR TITLE
Feature/pdct 1790 Ensure all family metadata values are string arrays

### DIFF
--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -115,6 +115,13 @@ def _validate_metadata(
             )
             continue
 
+        # Ensure all items in value_list are strings
+        if not all(isinstance(item, str) for item in value_list):
+            errors.append(
+                f"Invalid value(s) in '{value_list}' for metadata key '{key}', "
+                "expected all items to be strings."
+            )
+
         if not taxonomy_entry.allow_any:
             if not all(item in taxonomy_entry.allowed_values for item in value_list):
                 errors.append(f"Invalid value '{value_list}' for metadata key '{key}'")

--- a/db_client/functions/metadata.py
+++ b/db_client/functions/metadata.py
@@ -58,16 +58,23 @@ def validate_metadata(
         }
     else:
         taxonomy = get_entity_specific_taxonomy(taxonomy, entity_key)
-    return validate_metadata_against_taxonomy(taxonomy, metadata)
+
+    return validate_metadata_against_taxonomy(
+        taxonomy, metadata, bool(entity_key is None)
+    )
 
 
 def validate_metadata_against_taxonomy(
-    taxonomy: Union[TaxonomyData, TaxonomyDataEntry], metadata: TaxonomyDataEntry
+    taxonomy: Union[TaxonomyData, TaxonomyDataEntry],
+    metadata: TaxonomyDataEntry,
+    is_family_metadata: bool = False,
 ) -> Optional[MetadataValidationErrors]:
     """Build the Corpus taxonomy for the entity & validate against it.
 
     :param TaxonomyDataEntry taxonomy: The Corpus taxonomy to validate against.
     :param TaxonomyDataEntry metadata: The metadata to validate.
+    :param bool is_family_metadata: Whether to validate all metadata
+        values as string arrays.
     :raises TypeError: If the Taxonomy is invalid.
     :return Optional[MetadataValidationResult]: A list of errors or None
         if the metadata is valid.
@@ -79,18 +86,22 @@ def validate_metadata_against_taxonomy(
         # Wrap any TypeError in a more general error
         raise TypeError("Bad Taxonomy data in database") from e
 
-    errors = _validate_metadata(taxonomy_entries, metadata)
+    errors = _validate_metadata(taxonomy_entries, metadata, is_family_metadata)
     return errors if len(errors) > 0 else None
 
 
 def _validate_metadata(
-    taxonomy_entries: Mapping[str, TaxonomyEntry], metadata: Mapping
+    taxonomy_entries: Mapping[str, TaxonomyEntry],
+    metadata: Mapping,
+    is_family_metadata: bool = False,
 ) -> MetadataValidationErrors:
     """Validates the metadata against the taxonomy.
 
     :param _type_ taxonomy_entries: The built entries from the
         CorpusType.valid_metadata.
-    :param _type_ metadata: The metadata to validate.
+    :param Mapping metadata: The metadata to validate.
+    :param bool is_family_metadata: Whether to validate all metadata
+        values as string arrays.
     :return MetadataValidationErrors: a list of errors if the metadata
         is invalid.
     """
@@ -108,7 +119,7 @@ def _validate_metadata(
     for key, value_list in metadata.items():
         if key not in taxonomy_entries:
             continue  # We've already checked for missing keys
-        taxonomy_entry = taxonomy_entries[key]
+
         if not isinstance(value_list, list):
             errors.append(
                 f"Invalid value '{value_list}' for metadata key '{key}' expected list."
@@ -116,12 +127,14 @@ def _validate_metadata(
             continue
 
         # Ensure all items in value_list are strings
-        if not all(isinstance(item, str) for item in value_list):
+        if is_family_metadata and not all(isinstance(item, str) for item in value_list):
             errors.append(
                 f"Invalid value(s) in '{value_list}' for metadata key '{key}', "
                 "expected all items to be strings."
             )
+            continue
 
+        taxonomy_entry = taxonomy_entries[key]
         if not taxonomy_entry.allow_any:
             if not all(item in taxonomy_entry.allowed_values for item in value_list):
                 errors.append(f"Invalid value '{value_list}' for metadata key '{key}'")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.26"
+version = "3.8.27"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/functions/test_metadata.py
+++ b/tests/functions/test_metadata.py
@@ -224,3 +224,23 @@ def test_validation_allows_any(db):
     errors = validate_metadata_against_taxonomy(taxonomy, metadata)
 
     assert errors is None
+
+
+def test_validation_errors_on_non_string_values(db):
+    taxonomy = {
+        "author_type": {
+            "allow_blanks": False,
+            "allowed_values": ["Party", "Non-Party"],
+        }
+    }
+    metadata = {"author_type": ["Party", 123, None]}
+    setup_test(db, taxonomy, metadata)
+
+    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
+
+    assert errors is not None
+    assert len(errors) == 1
+    assert errors[0] == (
+        "Invalid value(s) in '['Party', 123, None]' for metadata key "
+        "'author_type', expected all items to be strings."
+    )

--- a/tests/functions/test_metadata.py
+++ b/tests/functions/test_metadata.py
@@ -236,7 +236,9 @@ def test_validation_errors_on_non_string_values(db):
     metadata = {"author_type": ["Party", 123, None]}
     setup_test(db, taxonomy, metadata)
 
-    errors = validate_metadata_against_taxonomy(taxonomy, metadata)
+    errors = validate_metadata_against_taxonomy(
+        taxonomy, metadata, is_family_metadata=True
+    )
 
     assert errors is not None
     assert len(errors) == 1


### PR DESCRIPTION
# What's changed

Ensure all family metadata values are string arrays

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
