### PR TITLE
feat: concepts on families

### DIFF
--- a/db_client/alembic/versions/0059_add_concepts.py
+++ b/db_client/alembic/versions/0059_add_concepts.py
@@ -7,7 +7,7 @@ Create Date: 2025-02-27 11:56:49.987901
 """
 
 from alembic import op
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, String
 
 from db_client.models.dfce.concept import Concept, FamilyConcept
 
@@ -30,6 +30,11 @@ def upgrade():
 
     if "family_concept" not in metadata.tables:
         FamilyConcept.__table__.create(bind)
+    else:
+        # Make the relation column nullable
+        op.alter_column(
+            "family_concept", "relation", existing_type=String(), nullable=True
+        )
 
 
 def downgrade():
@@ -38,6 +43,10 @@ def downgrade():
     metadata.reflect(bind=bind)
 
     if "family_concept" in metadata.tables:
+        # Make the relation column non-nullable again
+        op.alter_column(
+            "family_concept", "relation", existing_type=String(), nullable=False
+        )
         metadata.tables["family_concept"].drop(bind)
 
     if "concept" in metadata.tables:

--- a/db_client/alembic/versions/0059_add_concepts.py
+++ b/db_client/alembic/versions/0059_add_concepts.py
@@ -1,0 +1,45 @@
+"""Add reports which is a new corpus type to the family category model
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2025-02-27 11:56:49.987901
+
+"""
+
+from alembic import op
+from sqlalchemy import MetaData
+
+from db_client.models.dfce.concept import Concept, FamilyConcept
+
+# revision identifiers, used by Alembic.
+revision = "0059"
+down_revision = "0058"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Get the database connection from Alembic's context
+    bind = op.get_bind()
+
+    # Create concept and family_concept tables using the .create method
+    metadata = MetaData()
+    metadata.reflect(bind=bind)
+
+    if "concept" not in metadata.tables:
+        Concept.__table__.create(bind)
+
+    if "family_concept" not in metadata.tables:
+        FamilyConcept.__table__.create(bind)
+
+
+def downgrade():
+    bind = op.get_bind()
+    metadata = MetaData()
+    metadata.reflect(bind=bind)
+
+    if "family_concept" in metadata.tables:
+        metadata.tables["family_concept"].drop(bind)
+
+    if "concept" in metadata.tables:
+        metadata.tables["concept"].drop(bind)

--- a/db_client/alembic/versions/0059_add_concepts.py
+++ b/db_client/alembic/versions/0059_add_concepts.py
@@ -22,7 +22,6 @@ def upgrade():
     # Get the database connection from Alembic's context
     bind = op.get_bind()
 
-    # Create concept and family_concept tables using the .create method
     metadata = MetaData()
     metadata.reflect(bind=bind)
 

--- a/db_client/models/dfce/__init__.py
+++ b/db_client/models/dfce/__init__.py
@@ -9,6 +9,7 @@ from db_client.models.dfce.collection import (
     CollectionFamily,
     CollectionOrganisation,
 )
+from db_client.models.dfce.concept import Concept, FamilyConcept
 from db_client.models.dfce.family import (
     DocumentStatus,
     EventStatus,
@@ -28,6 +29,8 @@ __all__ = (
     "Collection",
     "CollectionFamily",
     "CollectionOrganisation",
+    "Concept",
+    "FamilyConcept",
     "DocumentStatus",
     "EventStatus",
     "Family",

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -79,6 +79,16 @@ class FamilyConcept(Base):
 
     concept_id = Column(ForeignKey(Concept.id), nullable=False)
     family_import_id = Column(ForeignKey(Family.import_id), nullable=False)
+    relation = Column(String, nullable=False)
+
+    # We don't base this on a DB enum as we will want to update it on regular intervals
+    @validates("relation")
+    def validate_relation(self, key, value):
+        valid_relations = ["author"]
+        if value not in valid_relations:
+            raise ValueError(f"relation must be one of {valid_relations}")
+        return value
+
     created = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     last_modified = Column(
         DateTime(timezone=True),

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -1,14 +1,9 @@
+from enum import Enum
+
 from pydantic import BaseModel, ValidationError
-from sqlalchemy import (
-    ARRAY,
-    Column,
-    DateTime,
-    ForeignKey,
-    PrimaryKeyConstraint,
-    String,
-    Text,
-    func,
-)
+from sqlalchemy import ARRAY, Column, DateTime
+from sqlalchemy import Enum as SQLAlchemyEnum
+from sqlalchemy import ForeignKey, PrimaryKeyConstraint, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, validates
 
@@ -19,6 +14,11 @@ from db_client.models.dfce.family import Family
 class ExternalIds(BaseModel):
     source: str
     id: str
+
+
+class ConceptType(str, Enum):
+    Laws = "laws"
+    LegalCategories = "legal_categories"
 
 
 class Concept(Base):
@@ -33,6 +33,7 @@ class Concept(Base):
     # This is used for any other ids e.g. wordpress, wikidata, etc.
     # The shape of this should be { "source": "climatecasechart.com/wp-json/wp/v2", "id": "case_category/415" }
     ids = Column(JSONB, nullable=False, default=list)
+    type = Column(SQLAlchemyEnum(ConceptType, native_enum=False), nullable=False)
     preferred_label = Column(String, nullable=False)
     alternative_labels = Column(ARRAY(String), nullable=True)
     negative_labels = Column(ARRAY(String), nullable=True)

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -96,4 +96,4 @@ class FamilyConcept(Base):
         onupdate=func.now(),
         nullable=False,
     )
-    PrimaryKeyConstraint(concept_id, family_import_id)
+    PrimaryKeyConstraint(concept_id, family_import_id, relation)

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -1,0 +1,67 @@
+from sqlalchemy import (
+    ARRAY,
+    Column,
+    DateTime,
+    ForeignKey,
+    PrimaryKeyConstraint,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.orm import relationship
+
+from db_client.models.base import Base
+from db_client.models.dfce.family import Family
+
+
+class Concept(Base):
+    """
+    This is a concept model from the knowledge graph project.
+    @see: https://github.com/climatepolicyradar/knowledge-graph/blob/main/src/concept.py
+    """
+
+    __tablename__ = "concept"
+
+    id = Column(String, primary_key=True)
+    preferred_label = Column(String, nullable=False)
+    alternative_labels = Column(ARRAY(String), nullable=True)
+    negative_labels = Column(ARRAY(String), nullable=True)
+    description = Column(Text, nullable=True)
+    wikibase_id = Column(String, nullable=True)
+    subconcept_of = Column(ARRAY(String), nullable=True)
+    has_subconcept = Column(ARRAY(String), nullable=True)
+    related_concepts = Column(ARRAY(String), nullable=True)
+    definition = Column(Text, nullable=True)
+
+    families = relationship(
+        "Family",
+        secondary="family_concept",
+        primaryjoin="Concept.id == FamilyConcept.concept_id",
+        secondaryjoin="Family.import_id == FamilyConcept.family_import_id",
+        back_populates="concepts",
+    )
+
+    created = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    last_modified = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class FamilyConcept(Base):
+    """Database model for a Family's Concepts"""
+
+    __tablename__ = "family_concept"
+
+    concept_id = Column(ForeignKey(Concept.id), nullable=False)
+    family_import_id = Column(ForeignKey(Family.import_id), nullable=False)
+    created = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    last_modified = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    PrimaryKeyConstraint(concept_id, family_import_id)

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 from sqlalchemy import ARRAY, Column, DateTime
 from sqlalchemy import Enum as SQLAlchemyEnum
 from sqlalchemy import ForeignKey, PrimaryKeyConstraint, String, Text, func
@@ -19,6 +19,8 @@ class ExternalIds(BaseModel):
 class ConceptType(str, Enum):
     Law = "law"
     LegalCategory = "legal_category"
+    Country = "country"
+    CountrySubdivision = "country_subdivision"
 
 
 class Concept(Base):
@@ -27,11 +29,11 @@ class Concept(Base):
     @see: https://github.com/climatepolicyradar/knowledge-graph/blob/main/src/concept.py
     """
 
-    __tablename__ = "concept"
+    __tablename__: str = "concept"
 
     id = Column(String, primary_key=True)
     # This is used for any other ids e.g. wordpress, wikidata, etc.
-    # The shape of this should be { "source": "climatecasechart.com/wp-json/wp/v2", "id": "case_category/415" }
+    # The shape of this should be ["climatecasechart.com/wp-json/wp/v2/case_category/415", "climatepolicyradar.wikibase.cloud/wiki/Item:Q1583"]
     ids = Column(JSONB, nullable=False, default=list)
     # This is similar to the `instance of` property in wikidata.
     # we've not gone with relationships here for ease of use,
@@ -44,21 +46,14 @@ class Concept(Base):
     description = Column(Text, nullable=True)
     wikibase_id = Column(String, nullable=True)
     subconcept_of_ids = Column(ARRAY(String), nullable=True)
-    has_subconcept_ids = Column(ARRAY(String), nullable=True)
-    related_concepts_ids = Column(ARRAY(String), nullable=True)
-    definition = Column(Text, nullable=True)
+    """
+    We don't currently do bi-directional mapping. This has been left here in case we want to get to it to make
+    our future-selves aware that there is an implementation
+    """
+    # has_subconcept_ids = Column(ARRAY(String), nullable=True)
+    # related_concepts_ids = Column(ARRAY(String), nullable=True)
 
-    @validates("ids")
-    def validate_ids(self, key, value):
-        if value is None:
-            return value
-        try:
-            [ExternalIds.model_validate(item) for item in value]
-        except ValidationError as e:
-            raise ValueError(
-                "ids should be a list[{ 'source': str, 'id': str }]"
-            ) from e
-        return value
+    definition = Column(Text, nullable=True)
 
     families = relationship(
         "Family",
@@ -66,6 +61,7 @@ class Concept(Base):
         primaryjoin="Concept.id == FamilyConcept.concept_id",
         secondaryjoin="Family.import_id == FamilyConcept.family_import_id",
         back_populates="concepts",
+        order_by="Family.import_id",
     )
 
     created = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -93,7 +89,7 @@ class FamilyConcept(Base):
     def validate_relation(self, key, value):
         # NOTICE: this is a hyper-controlled vocabulary and we should seek advice from other teams before updating it
         # TODO: make a note of who is actually controlling this vocabulary
-        valid_relations = ["author"]
+        valid_relations = ["author", "jurisdiction"]
         if value is None:
             return value
 

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -91,9 +91,12 @@ class FamilyConcept(Base):
     # bar that it is related.
     @validates("relation")
     def validate_relation(self, key, value):
+        # NOTICE: this is a hyper-controlled vocabulary and we should seek advice from other teams before updating it
+        # TODO: make a note of who is actually controlling this vocabulary
+        valid_relations = ["author"]
         if value is None:
             return value
-        valid_relations = ["author"]
+
         if value not in valid_relations:
             raise ValueError(f"relation must be one of {valid_relations}")
         return value

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -17,8 +17,8 @@ class ExternalIds(BaseModel):
 
 
 class ConceptType(str, Enum):
-    Laws = "laws"
-    LegalCategories = "legal_categories"
+    Law = "law"
+    LegalCategory = "legal_category"
 
 
 class Concept(Base):

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -79,11 +79,15 @@ class FamilyConcept(Base):
 
     concept_id = Column(ForeignKey(Concept.id), nullable=False)
     family_import_id = Column(ForeignKey(Family.import_id), nullable=False)
-    relation = Column(String, nullable=False)
+    relation = Column(String, nullable=True)
 
     # We don't base this on a DB enum as we will want to update it on regular intervals
+    # A None relation means we have not found a better way to descr
+    # bar that it is related.
     @validates("relation")
     def validate_relation(self, key, value):
+        if value is None:
+            return value
         valid_relations = ["author"]
         if value not in valid_relations:
             raise ValueError(f"relation must be one of {valid_relations}")

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -43,9 +43,9 @@ class Concept(Base):
     negative_labels = Column(ARRAY(String), nullable=True)
     description = Column(Text, nullable=True)
     wikibase_id = Column(String, nullable=True)
-    subconcept_of = Column(ARRAY(String), nullable=True)
-    has_subconcept = Column(ARRAY(String), nullable=True)
-    related_concepts = Column(ARRAY(String), nullable=True)
+    subconcept_of_ids = Column(ARRAY(String), nullable=True)
+    has_subconcept_ids = Column(ARRAY(String), nullable=True)
+    related_concepts_ids = Column(ARRAY(String), nullable=True)
     definition = Column(Text, nullable=True)
 
     @validates("ids")

--- a/db_client/models/dfce/concept.py
+++ b/db_client/models/dfce/concept.py
@@ -33,6 +33,10 @@ class Concept(Base):
     # This is used for any other ids e.g. wordpress, wikidata, etc.
     # The shape of this should be { "source": "climatecasechart.com/wp-json/wp/v2", "id": "case_category/415" }
     ids = Column(JSONB, nullable=False, default=list)
+    # This is similar to the `instance of` property in wikidata.
+    # we've not gone with relationships here for ease of use,
+    # but this would allow us to persue that at a later date
+    # @see https://www.wikidata.org/wiki/Property:P31
     type = Column(SQLAlchemyEnum(ConceptType, native_enum=False), nullable=False)
     preferred_label = Column(String, nullable=False)
     alternative_labels = Column(ARRAY(String), nullable=True)

--- a/db_client/models/dfce/family.py
+++ b/db_client/models/dfce/family.py
@@ -74,6 +74,7 @@ class Family(Base):
         secondaryjoin="Geography.id == FamilyGeography.geography_id",
         order_by="Geography.slug",
     )
+
     concepts = relationship(
         "Concept",
         secondary="family_concept",
@@ -81,6 +82,7 @@ class Family(Base):
         secondaryjoin="Concept.id == FamilyConcept.concept_id",
         back_populates="families",
     )
+
     events: list["FamilyEvent"] = relationship(
         "FamilyEvent",
         lazy="joined",

--- a/db_client/models/dfce/family.py
+++ b/db_client/models/dfce/family.py
@@ -74,6 +74,13 @@ class Family(Base):
         secondaryjoin="Geography.id == FamilyGeography.geography_id",
         order_by="Geography.slug",
     )
+    concepts = relationship(
+        "Concept",
+        secondary="family_concept",
+        primaryjoin="Family.import_id == FamilyConcept.family_import_id",
+        secondaryjoin="Concept.id == FamilyConcept.concept_id",
+        back_populates="families",
+    )
     events: list["FamilyEvent"] = relationship(
         "FamilyEvent",
         lazy="joined",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [tool.poetry]
 name = "db-client"
-<<<<<<< HEAD
-version = "3.9.6"
-=======
-version = "3.8.30"
->>>>>>> 1662926 (chore(version): bump version)
+version = "3.9.8"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.9.4"
+version = "3.9.6"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [tool.poetry]
 name = "db-client"
+<<<<<<< HEAD
 version = "3.9.6"
+=======
+version = "3.8.30"
+>>>>>>> 1662926 (chore(version): bump version)
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [tool.poetry]
 name = "db-client"
+<<<<<<< HEAD
 version = "3.9.8"
+=======
+version = "3.9.4"
+>>>>>>> 0d721b8 (chore(deps): bump version)
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [tool.poetry]
 name = "db-client"
-<<<<<<< HEAD
-version = "3.9.8"
-=======
-version = "3.9.4"
->>>>>>> 0d721b8 (chore(deps): bump version)
+version = "3.9.9"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,11 @@ def test_db(test_engine_fixture):
         connection = test_engine.connect()
 
         run_migrations(test_engine)  # type: ignore for MockConnection
+
+        # Create tables that are not in migrations
+        Base.metadata.tables["concept"].create(test_engine)
+        Base.metadata.tables["family_concept"].create(test_engine)
+
         test_session_maker = sessionmaker(
             autocommit=False,
             autoflush=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,10 +73,6 @@ def test_db(test_engine_fixture):
 
         run_migrations(test_engine)  # type: ignore for MockConnection
 
-        # Create tables that are not in migrations
-        Base.metadata.tables["concept"].create(test_engine)
-        Base.metadata.tables["family_concept"].create(test_engine)
-
         test_session_maker = sessionmaker(
             autocommit=False,
             autoflush=False,

--- a/tests/functions/dfce_helpers/test_add_concepts.py
+++ b/tests/functions/dfce_helpers/test_add_concepts.py
@@ -44,4 +44,5 @@ def test_add_concepts(test_db):
     families = test_db.query(Family).all()
     assert len(families) == 1
 
-    print(families[0])
+    assert len(families[0].concepts) == 1
+    assert families[0].concepts[0].id == concept1.id

--- a/tests/functions/dfce_helpers/test_add_concepts.py
+++ b/tests/functions/dfce_helpers/test_add_concepts.py
@@ -14,9 +14,9 @@ def test_add_concepts(test_db):
         negative_labels=[],
         description="Organisation and governance instruments let governments act directly on individuals, property, or the environment, enhancing institutions' capacity for climate action through new roles, bodies, and strategies.",
         wikibase_id="Q1209",
-        subconcept_of=["Q1171"],
-        has_subconcept=["Q1292", "Q1293", "Q1294", "Q1295", "Q1296"],
-        related_concepts=[],
+        subconcept_of_ids=["Q1171"],
+        has_subconcept_ids=["Q1292", "Q1293", "Q1294", "Q1295", "Q1296"],
+        related_concepts_ids=[],
         definition='Allows governments to act directly on individuals, their property, or the environment, focusing on "effecting" rather than detecting. In climate policy, they are designed to enhance institutions\' capacity to address climate change. This includes granting new responsibilities to existing bodies, creating new institutions, and developing governance plans and strategies.',
     )
     family1 = Family(

--- a/tests/functions/dfce_helpers/test_add_concepts.py
+++ b/tests/functions/dfce_helpers/test_add_concepts.py
@@ -1,0 +1,42 @@
+from db_client.models.dfce.concept import Concept, FamilyConcept
+from db_client.models.dfce.family import Family, FamilyCategory
+
+
+def test_add_concepts(test_db):
+    concept1 = Concept(
+        id="Q1209",
+        preferred_label="organisation and governance instrument",
+        alternative_labels=["organisation instrument"],
+        negative_labels=[],
+        description="Organisation and governance instruments let governments act directly on individuals, property, or the environment, enhancing institutions' capacity for climate action through new roles, bodies, and strategies.",
+        wikibase_id="Q1209",
+        subconcept_of=["Q1171"],
+        has_subconcept=["Q1292", "Q1293", "Q1294", "Q1295", "Q1296"],
+        related_concepts=[],
+        definition='Allows governments to act directly on individuals, their property, or the environment, focusing on "effecting" rather than detecting. In climate policy, they are designed to enhance institutions\' capacity to address climate change. This includes granting new responsibilities to existing bodies, creating new institutions, and developing governance plans and strategies.',
+    )
+    family1 = Family(
+        import_id="Family1",
+        title="Family1",
+        description="FamilySummary1",
+        family_category=FamilyCategory.EXECUTIVE,
+    )
+
+    family_concept1 = FamilyConcept(
+        family_import_id=family1.import_id,
+        concept_id=concept1.id,
+    )
+    test_db.add(concept1)
+    test_db.add(family1)
+    test_db.commit()
+
+    test_db.add(family_concept1)
+    test_db.commit()
+
+    concepts = test_db.query(Concept).all()
+    assert len(concepts) == 1
+
+    families = test_db.query(Family).all()
+    assert len(families) == 1
+
+    print(families[0])

--- a/tests/functions/dfce_helpers/test_add_concepts.py
+++ b/tests/functions/dfce_helpers/test_add_concepts.py
@@ -28,6 +28,7 @@ def test_add_concepts(test_db):
     family_concept1 = FamilyConcept(
         family_import_id=family1.import_id,
         concept_id=concept1.id,
+        relation="author",
     )
     test_db.add(concept1)
     test_db.add(family1)

--- a/tests/functions/dfce_helpers/test_add_concepts.py
+++ b/tests/functions/dfce_helpers/test_add_concepts.py
@@ -5,6 +5,9 @@ from db_client.models.dfce.family import Family, FamilyCategory
 def test_add_concepts(test_db):
     concept1 = Concept(
         id="Q1209",
+        ids=[
+            {"source": "climatecasechart.com/wp-json/wp/v2", "id": "case_category/415"}
+        ],
         preferred_label="organisation and governance instrument",
         alternative_labels=["organisation instrument"],
         negative_labels=[],

--- a/tests/functions/dfce_helpers/test_add_concepts.py
+++ b/tests/functions/dfce_helpers/test_add_concepts.py
@@ -8,7 +8,7 @@ def test_add_concepts(test_db):
         ids=[
             {"source": "climatecasechart.com/wp-json/wp/v2", "id": "case_category/415"}
         ],
-        type=ConceptType.Laws,
+        type=ConceptType.Law,
         preferred_label="organisation and governance instrument",
         alternative_labels=["organisation instrument"],
         negative_labels=[],

--- a/tests/functions/dfce_helpers/test_add_concepts.py
+++ b/tests/functions/dfce_helpers/test_add_concepts.py
@@ -1,4 +1,4 @@
-from db_client.models.dfce.concept import Concept, FamilyConcept
+from db_client.models.dfce.concept import Concept, ConceptType, FamilyConcept
 from db_client.models.dfce.family import Family, FamilyCategory
 
 
@@ -8,6 +8,7 @@ def test_add_concepts(test_db):
         ids=[
             {"source": "climatecasechart.com/wp-json/wp/v2", "id": "case_category/415"}
         ],
+        type=ConceptType.Laws,
         preferred_label="organisation and governance instrument",
         alternative_labels=["organisation instrument"],
         negative_labels=[],


### PR DESCRIPTION
# What's changed
- implemented `concepts` on `families`

The concepts implemented is very similar to the [Knowledge Graph concepts](https://github.com/climatepolicyradar/knowledge-graph/blob/main/src/concept.py#L18) with a few tweaks that we have tried to not tie us into corners, but allow us to move forward.

- `_ids` postfix to related concepts. This is because that is what they are and would allow us to populate `related_concepts` with actual concepts in the future relatively easily.
- added `ids` field. This is for external IDs so that we can query them by IDs outside of our system e.g. `wordpress` when updating from source data
- new `type` field. This is born of a requirement of litigation, but feels like a good addition. In the perfect world - we might have "Laws" or "Legal category" as a super-concept, but I think that would add too much complexity in this first iteration. We can sunset this if we do that in future
- adds the `relation` data. This is an addition to the Knowledge Graph concepts implementation. It allows us to define the nature of a relationship between a family and a concept

Part of https://linear.app/climate-policy-radar/issue/APP-309/add-concepts-table-and-link-to-family

## Proposed version

- [x] Patch
