### PR TITLE
Feature/app 308 bug admin frontend showing incorrect changed dates

### DIFF
--- a/db_client/models/dfce/family.py
+++ b/db_client/models/dfce/family.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal, Optional, cast
 
 import sqlalchemy as sa
@@ -178,10 +178,11 @@ class Family(Base):
             return None
         date = None
         for event in self.events:
-            if date is None:
-                date = cast(datetime, event.date)
-            else:
-                date = max(cast(datetime, event.date), date)
+            if event.date <= datetime.now(tz=timezone.utc):
+                if date is None:
+                    date = cast(datetime, event.date)
+                else:
+                    date = max(cast(datetime, event.date), date)
         return date
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.28"
+version = "3.8.29"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/functions/test_retrieve_family_last_updated_date.py
+++ b/tests/functions/test_retrieve_family_last_updated_date.py
@@ -19,12 +19,8 @@ def test_calculates_last_updated_dates_based_on_latest_family_event(test_db):
     test_db.add(family_data)
     test_db.commit()
 
-    approved_event_date = datetime.now(tz=timezone.utc) - timedelta(
-        days=365
-    )  # 1 year ago
-    passed_event_date = datetime.now(tz=timezone.utc) - timedelta(
-        days=180
-    )  # 6 months ago
+    approved_event_date = datetime.now(tz=timezone.utc) - timedelta(days=365)
+    passed_event_date = datetime.now(tz=timezone.utc) - timedelta(days=180)
 
     approved_event = FamilyEvent(
         import_id="event_import_id_1",

--- a/tests/functions/test_retrieve_family_last_updated_date.py
+++ b/tests/functions/test_retrieve_family_last_updated_date.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta, timezone
+
+from db_client.models.dfce.family import (
+    EventStatus,
+    Family,
+    FamilyCategory,
+    FamilyEvent,
+)
+
+
+def test_calculates_last_updated_dates_based_on_latest_family_event(test_db):
+    family_data = Family(
+        import_id="family_import_id_1",
+        title="Test Family Title",
+        description="Test Family Description",
+        family_category=FamilyCategory.EXECUTIVE,
+    )
+
+    test_db.add(family_data)
+    test_db.commit()
+
+    approved_event_date = datetime.now(tz=timezone.utc) - timedelta(
+        days=365
+    )  # 1 year ago
+    passed_event_date = datetime.now(tz=timezone.utc) - timedelta(
+        days=180
+    )  # 6 months ago
+
+    approved_event = FamilyEvent(
+        import_id="event_import_id_1",
+        title="Event Title Approved",
+        date=approved_event_date,
+        family_import_id=family_data.import_id,
+        status=EventStatus.OK,
+        event_type_name="Approved",
+    )
+
+    passed_event = FamilyEvent(
+        import_id="event_import_id_2",
+        title="Event Title Passed",
+        date=passed_event_date,
+        family_import_id=family_data.import_id,
+        status=EventStatus.OK,
+        event_type_name="Passed",
+    )
+
+    test_db.add(approved_event)
+    test_db.add(passed_event)
+    test_db.commit()
+
+    families = test_db.query(Family).all()
+    assert len(families) == 1
+
+    family = families[0]
+
+    assert len(family.events) == 2
+    assert families[0].last_updated_date == passed_event_date
+
+
+def test_family_last_updated_date_excludes_event_dates_in_the_future(test_db):
+
+    family_data = Family(
+        import_id="family_import_id_1",
+        title="Test Family Title",
+        description="Test Family Description",
+        family_category=FamilyCategory.EXECUTIVE,
+    )
+
+    test_db.add(family_data)
+    test_db.commit()
+
+    approved_event_date = datetime.now(tz=timezone.utc) - timedelta(days=365)
+    passed_event_date = datetime.now(tz=timezone.utc) - timedelta(days=180)
+    future_completed_date = datetime.now(tz=timezone.utc) + timedelta(days=365)
+
+    approved_event = FamilyEvent(
+        import_id="event_import_id_1",
+        title="Event Title Approved",
+        date=approved_event_date,
+        family_import_id=family_data.import_id,
+        status=EventStatus.OK,
+        event_type_name="Approved",
+    )
+
+    passed_event = FamilyEvent(
+        import_id="event_import_id_2",
+        title="Event Title Passed",
+        date=passed_event_date,
+        family_import_id=family_data.import_id,
+        status=EventStatus.OK,
+        event_type_name="Passed",
+    )
+
+    future_completed_event = FamilyEvent(
+        import_id="event_import_id_3",
+        title="Event Title Completed",
+        date=future_completed_date,
+        family_import_id=family_data.import_id,
+        status=EventStatus.OK,
+        event_type_name="Completed",
+    )
+
+    test_db.add(approved_event)
+    test_db.add(passed_event)
+    test_db.add(future_completed_event)
+    test_db.commit()
+
+    families = test_db.query(Family).all()
+    assert len(families) == 1
+
+    family = families[0]
+
+    assert len(families) == 1
+    assert len(family.events) == 3
+    assert family.last_updated_date == passed_event_date


### PR DESCRIPTION
# What's changed

Add a check to ensure that when we create the family `last_updated_date`, we exclude any events that have a date set to the future. We only set the latest event date based on those that are before or on the current date time. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
