### PR TITLE
Feature/app 345 add metadata to collections

### DIFF
--- a/db_client/alembic/versions/0059_add_valid_metadata_to_collection_table.py
+++ b/db_client/alembic/versions/0059_add_valid_metadata_to_collection_table.py
@@ -1,0 +1,37 @@
+"""Add valid_metadata column to the collection table
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2025-03-06 12:23:22.657834
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0059"
+down_revision = "0058"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "collection", sa.Column("valid_metadata", postgresql.JSONB, nullable=True)
+    )
+    op.execute(
+        sa.text(
+            "UPDATE collection "
+            "SET valid_metadata = '{}' "
+            "WHERE valid_metadata IS NULL"
+        )
+    )
+    op.alter_column(
+        "collection", "valid_metadata", existing_type=postgresql.JSONB, nullable=False
+    )
+
+
+def downgrade():
+    op.drop_column("collection", "valid_metadata")

--- a/db_client/functions/dfce_helpers.py
+++ b/db_client/functions/dfce_helpers.py
@@ -43,7 +43,7 @@ def add_collections(db: Session, collections, org_id=1):
                 import_id=c["import_id"],
                 title=c["title"],
                 description=c["description"],
-                valid_metadata=c["valid_metadata"],
+                valid_metadata=c["metadata"],
             )
         )
     db.flush()

--- a/db_client/functions/dfce_helpers.py
+++ b/db_client/functions/dfce_helpers.py
@@ -43,6 +43,7 @@ def add_collections(db: Session, collections, org_id=1):
                 import_id=c["import_id"],
                 title=c["title"],
                 description=c["description"],
+                valid_metadata=c["valid_metadata"],
             )
         )
     db.flush()

--- a/db_client/models/dfce/collection.py
+++ b/db_client/models/dfce/collection.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from db_client.models.base import Base
 from db_client.models.dfce.family import Family
@@ -13,6 +14,7 @@ class Collection(Base):
     import_id = sa.Column(sa.Text, primary_key=True)
     title = sa.Column(sa.Text, nullable=False)
     description = sa.Column(sa.Text, nullable=False)
+    valid_metadata = sa.Column(postgresql.JSONB, nullable=False)
     created = sa.Column(
         sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.8.29"
+version = "3.9.0"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/functions/dfce_helpers/test_add_collections.py
+++ b/tests/functions/dfce_helpers/test_add_collections.py
@@ -7,7 +7,7 @@ def test_add_collections__one_collection(test_db):
         "import_id": "CPR.Collection.1.0",
         "title": "Collection1",
         "description": "CollectionSummary1",
-        "valid_metadata": {"key": "value"},
+        "metadata": {"key": "value"},
     }
     add_collections(test_db, collections=[collection1])
 
@@ -26,13 +26,13 @@ def test_add_collections__multiple_collections(test_db):
         "import_id": "CPR.Collection.1.0",
         "title": "Collection1",
         "description": "CollectionSummary1",
-        "valid_metadata": {},
+        "metadata": {},
     }
     collection2 = {
         "import_id": "CPR.Collection.2.0",
         "title": "Collection2",
         "description": "CollectionSummary2",
-        "valid_metadata": {},
+        "metadata": {},
     }
     add_collections(test_db, collections=[collection1, collection2])
 
@@ -52,7 +52,7 @@ def test_add_collections__organisations(test_db):
         "import_id": "CPR.Collection.1.0",
         "title": "Collection1",
         "description": "CollectionSummary1",
-        "valid_metadata": {},
+        "metadata": {},
     }
     add_collections(test_db, collections=[collection1])
 

--- a/tests/functions/dfce_helpers/test_add_collections.py
+++ b/tests/functions/dfce_helpers/test_add_collections.py
@@ -7,6 +7,7 @@ def test_add_collections__one_collection(test_db):
         "import_id": "CPR.Collection.1.0",
         "title": "Collection1",
         "description": "CollectionSummary1",
+        "valid_metadata": {"key": "value"},
     }
     add_collections(test_db, collections=[collection1])
 
@@ -17,6 +18,7 @@ def test_add_collections__one_collection(test_db):
     assert collection.import_id == "CPR.Collection.1.0"
     assert collection.title == "Collection1"
     assert collection.description == "CollectionSummary1"
+    assert collection.valid_metadata == {"key": "value"}
 
 
 def test_add_collections__multiple_collections(test_db):
@@ -24,11 +26,13 @@ def test_add_collections__multiple_collections(test_db):
         "import_id": "CPR.Collection.1.0",
         "title": "Collection1",
         "description": "CollectionSummary1",
+        "valid_metadata": {},
     }
     collection2 = {
         "import_id": "CPR.Collection.2.0",
         "title": "Collection2",
         "description": "CollectionSummary2",
+        "valid_metadata": {},
     }
     add_collections(test_db, collections=[collection1, collection2])
 
@@ -48,6 +52,7 @@ def test_add_collections__organisations(test_db):
         "import_id": "CPR.Collection.1.0",
         "title": "Collection1",
         "description": "CollectionSummary1",
+        "valid_metadata": {},
     }
     add_collections(test_db, collections=[collection1])
 

--- a/tests/functions/dfce_helpers/test_add_families.py
+++ b/tests/functions/dfce_helpers/test_add_families.py
@@ -31,6 +31,7 @@ def test_add_families__link_collection_family(test_db):
         "import_id": "CPR.Collection.1.0",
         "title": "Collection1",
         "description": "CollectionSummary1",
+        "metadata": {},
     }
     add_collections(test_db, collections=[collection])
 


### PR DESCRIPTION
# What's changed
- add valid_metadata column to the collection table to accommodate capturing of external id on collections (i.e. US case bundles)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
