### PR TITLE
feat: add attribution url to organisation table

### DIFF
--- a/db_client/alembic/versions/0070_add_attribution_url_column_to_.py
+++ b/db_client/alembic/versions/0070_add_attribution_url_column_to_.py
@@ -7,7 +7,6 @@ Create Date: 2025-07-29 14:12:10.294378
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/db_client/alembic/versions/0070_add_attribution_url_column_to_.py
+++ b/db_client/alembic/versions/0070_add_attribution_url_column_to_.py
@@ -1,0 +1,29 @@
+"""Add attribution url column to organisation table
+
+Revision ID: 0070
+Revises: 0069
+Create Date: 2025-07-29 14:12:10.294378
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0070"
+down_revision = "0069"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "organisation", sa.Column("attribution_url", sa.String(), nullable=True)
+    )
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.drop_column("organisation", "attribution_url")
+    # ### end Alembic commands ###

--- a/db_client/models/organisation/organisation.py
+++ b/db_client/models/organisation/organisation.py
@@ -13,3 +13,4 @@ class Organisation(Base):
     display_name = sa.Column(sa.String, nullable=False)
     description = sa.Column(sa.String)
     organisation_type = sa.Column(sa.String)
+    attribution_url = sa.Column(sa.String, nullable=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.9.17"
+version = "3.9.18"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

Add attribution url to organisation table

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
