### PR TITLE
feat: add attribution_url to corpus

### DIFF
--- a/db_client/alembic/versions/0071_add_attribution_url_column_to_corpus.py
+++ b/db_client/alembic/versions/0071_add_attribution_url_column_to_corpus.py
@@ -1,0 +1,26 @@
+"""Add attribution url column to corpus table
+
+Revision ID: 0071
+Revises: 0070
+Create Date: 2025-08-06 14:12:10.294378
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0071"
+down_revision = "0070"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("corpus", sa.Column("attribution_url", sa.String(), nullable=True))
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.drop_column("corpus", "attribution_url")
+    # ### end Alembic commands ###

--- a/db_client/models/organisation/corpus.py
+++ b/db_client/models/organisation/corpus.py
@@ -25,3 +25,4 @@ class Corpus(Base):
     corpus_image_url = sa.Column(sa.Text)
     organisation_id = sa.Column(sa.ForeignKey(Organisation.id), nullable=False)
     corpus_type_name = sa.Column(sa.ForeignKey(CorpusType.name), nullable=False)
+    attribution_url = sa.Column(sa.String, nullable=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "db-client"
-version = "3.9.18"
+version = "3.9.19"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# What's changed

We need the attribution to be at a corpus level.

I would have suggested just relating e.g.  CCLW => PreventionWeb, but our access control in the admin-service is coupled to this.

## Proposed version

- [x] Patch
